### PR TITLE
reduce length of branch name used in url

### DIFF
--- a/bin/uat_deploy
+++ b/bin/uat_deploy
@@ -2,7 +2,7 @@
 
 deploy() {
   IMG_REPO="$ECR_ENDPOINT"
-  RELEASE_NAME=$(echo $CIRCLE_BRANCH | tr '[:upper:]' '[:lower:]' | sed 's:^\w*\/::' | tr -s ' _/[]().' '-' | cut -c1-30 | sed 's/-$//')
+  RELEASE_NAME=$(echo $CIRCLE_BRANCH | tr '[:upper:]' '[:lower:]' | sed 's:^\w*\/::' | tr -s ' _/[]().' '-' | cut -c1-20 | sed 's/-$//')
   RELEASE_HOST="$RELEASE_NAME-check-financial-partner-uat.cloud-platform.service.justice.gov.uk"
   IDENTIFIER="$RELEASE_NAME-check-financial-partner-check-financial-eligibility-partner-uat-green"
 


### PR DESCRIPTION
## What
As per the thread here: https://mojdt.slack.com/archives/C57UPMZLY/p1669205595197459?thread_ts=1668712333.005529&cid=C57UPMZLY
We need to reduce the length of the name we use for URLs for UAT deployments, this matches what we do on the other repo

Describe what you did and why.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
