### PR TITLE
EL-515: Stop trying to assess smod value prematurely

### DIFF
--- a/app/services/calculators/subject_matter_of_dispute_disregard_calculator.rb
+++ b/app/services/calculators/subject_matter_of_dispute_disregard_calculator.rb
@@ -1,10 +1,12 @@
+# WARNING: This calculator assumes that the assessed value/equity of all disputed properties and vehicles
+# has already been calculated. If this is not the case, it will produce inaccurate results.
 module Calculators
   class SubjectMatterOfDisputeDisregardCalculator
     delegate :disputed_capital_items, :disputed_vehicles, :disputed_properties, to: :@capital_summary
 
-    def initialize(submission_date:, capital_summary:)
-      @submission_date = submission_date
+    def initialize(capital_summary:, maximum_disregard:)
       @capital_summary = capital_summary
+      @maximum_disregard = maximum_disregard
     end
 
     def value
@@ -12,18 +14,14 @@ module Calculators
         disputed_property_value +
         disputed_vehicle_value
 
-      if total_disputed_asset_value.positive? && threshold.nil?
-        raise "SMOD assets listed but no threshold data found for #{@submission_date}"
+      if total_disputed_asset_value.positive? && @maximum_disregard.nil?
+        raise "SMOD assets listed but no threshold data found"
       end
 
-      [total_disputed_asset_value, threshold].compact.min
+      [total_disputed_asset_value, @maximum_disregard].compact.min
     end
 
   private
-
-    def threshold
-      @threshold ||= Threshold.value_for(:subject_matter_of_dispute_disregard, at: @submission_date)
-    end
 
     def disputed_capital_value
       disputed_capital_items.sum(:value)

--- a/app/services/capital_collator_and_assessor.rb
+++ b/app/services/capital_collator_and_assessor.rb
@@ -1,12 +1,10 @@
 class CapitalCollatorAndAssessor
   class << self
     def call(assessment)
-      smod_disregard = Calculators::SubjectMatterOfDisputeDisregardCalculator.new(submission_date: assessment.submission_date,
-                                                                                  capital_summary: assessment.capital_summary).value
       data = Collators::CapitalCollator.call(
         submission_date: assessment.submission_date,
         capital_summary: assessment.capital_summary,
-        subject_matter_of_dispute_disregard: smod_disregard,
+        maximum_subject_matter_of_dispute_disregard: maximum_subject_matter_of_dispute_disregard(assessment),
         pensioner_capital_disregard: pensioner_capital_disregard(assessment),
       )
       assessment.capital_summary.update!(data)
@@ -14,8 +12,8 @@ class CapitalCollatorAndAssessor
         partner_data = Collators::CapitalCollator.call(
           submission_date: assessment.submission_date,
           capital_summary: assessment.partner_capital_summary,
-          subject_matter_of_dispute_disregard: 0,
           pensioner_capital_disregard: 0,
+          maximum_subject_matter_of_dispute_disregard: 0,
         )
         assessment.partner_capital_summary.update!(partner_data)
         assessment.capital_summary.update!(combined_assessed_capital: assessment.capital_summary.assessed_capital +
@@ -53,6 +51,10 @@ class CapitalCollatorAndAssessor
         ).value
       end
       [applicant_value, partner_value].compact.max
+    end
+
+    def maximum_subject_matter_of_dispute_disregard(assessment)
+      Threshold.value_for(:subject_matter_of_dispute_disregard, at: assessment.submission_date)
     end
   end
 end

--- a/app/services/collators/capital_collator.rb
+++ b/app/services/collators/capital_collator.rb
@@ -14,16 +14,16 @@ module Collators
     }.freeze
 
     class << self
-      def call(submission_date:, capital_summary:, pensioner_capital_disregard:, subject_matter_of_dispute_disregard:)
-        new(submission_date:, capital_summary:, subject_matter_of_dispute_disregard:, pensioner_capital_disregard:).call
+      def call(submission_date:, capital_summary:, pensioner_capital_disregard:, maximum_subject_matter_of_dispute_disregard:)
+        new(submission_date:, capital_summary:, pensioner_capital_disregard:, maximum_subject_matter_of_dispute_disregard:).call
       end
     end
 
-    def initialize(submission_date:, capital_summary:, pensioner_capital_disregard:, subject_matter_of_dispute_disregard:)
+    def initialize(submission_date:, capital_summary:, pensioner_capital_disregard:, maximum_subject_matter_of_dispute_disregard:)
       @submission_date = submission_date
       @capital_summary = capital_summary
       @pensioner_capital_disregard = pensioner_capital_disregard
-      @subject_matter_of_dispute_disregard = subject_matter_of_dispute_disregard
+      @maximum_subject_matter_of_dispute_disregard = maximum_subject_matter_of_dispute_disregard
     end
 
     def call
@@ -32,10 +32,15 @@ module Collators
 
   private
 
-    attr_reader :pensioner_capital_disregard, :subject_matter_of_dispute_disregard
+    attr_reader :pensioner_capital_disregard
 
     def assessed_capital
       total_capital - pensioner_capital_disregard - subject_matter_of_dispute_disregard
+    end
+
+    def subject_matter_of_dispute_disregard
+      Calculators::SubjectMatterOfDisputeDisregardCalculator.new(capital_summary: @capital_summary,
+                                                                 maximum_disregard: @maximum_subject_matter_of_dispute_disregard).value
     end
 
     def total_capital

--- a/db/migrate/20221128152328_make_assessed_values_nullable.rb
+++ b/db/migrate/20221128152328_make_assessed_values_nullable.rb
@@ -1,0 +1,11 @@
+class MakeAssessedValuesNullable < ActiveRecord::Migration[7.0]
+  def up
+    change_column :properties, :assessed_equity, :decimal, null: true, default: nil
+    change_column :vehicles, :assessed_value, :decimal, null: true, default: nil
+  end
+
+  def down
+    change_column :properties, :assessed_equity, :decimal, null: false, default: 0
+    change_column :vehicles, :assessed_value, :decimal, null: false, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_11_24_120203) do
+ActiveRecord::Schema[7.0].define(version: 2022_11_28_152328) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -322,7 +322,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_24_120203) do
     t.decimal "allowable_outstanding_mortgage", default: "0.0", null: false
     t.decimal "net_value", default: "0.0", null: false
     t.decimal "net_equity", default: "0.0", null: false
-    t.decimal "assessed_equity", default: "0.0", null: false
+    t.decimal "assessed_equity"
     t.decimal "main_home_equity_disregard", default: "0.0", null: false
     t.boolean "subject_matter_of_dispute"
     t.index ["capital_summary_id"], name: "index_properties_on_capital_summary_id"
@@ -394,7 +394,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_24_120203) do
     t.datetime "updated_at", precision: nil, null: false
     t.uuid "capital_summary_id"
     t.boolean "included_in_assessment", default: false, null: false
-    t.decimal "assessed_value", default: "0.0", null: false
+    t.decimal "assessed_value"
     t.boolean "subject_matter_of_dispute"
     t.index ["capital_summary_id"], name: "index_vehicles_on_capital_summary_id"
   end

--- a/features/disputed_assets/disputed_property.feature
+++ b/features/disputed_assets/disputed_property.feature
@@ -1,0 +1,44 @@
+Feature:
+    "I have a property that is disputed"
+
+    Scenario: A SMOD property below the threshold is disregarded.
+        Given I am undertaking a standard assessment with an applicant who receives passporting benefits
+        And I add the following main property details for the current assessment:
+            | value                     | 150000 |
+            | outstanding_mortgage      | 0      |
+            | percentage_owned          | 100    |
+            | shared_with_housing_assoc | false  |
+            | subject_matter_of_dispute | true   |
+        When I retrieve the final assessment
+        Then I should see the following "main property" details:
+            | attribute                  | value    |
+            | value                      | 150000.0 |
+            | main_home_equity_disregard | 100000.0 |
+            | transaction_allowance      | 4500.0   |
+            | assessed_equity            | 45500.0  |
+        And I should see the following "capital summary" details:
+            | attribute                           | value   |
+            | total_property                      | 45500.0 |
+            | subject_matter_of_dispute_disregard | 45500.0 |
+            | assessed_capital                    | 0.0     |
+
+    Scenario: SMOD is capped if the threshold is exceeded.
+        Given I am undertaking a standard assessment with an applicant who receives passporting benefits
+        And I add the following main property details for the current assessment:
+            | value                     | 250000 |
+            | outstanding_mortgage      | 0      |
+            | percentage_owned          | 100    |
+            | shared_with_housing_assoc | false  |
+            | subject_matter_of_dispute | true   |
+        When I retrieve the final assessment
+        Then I should see the following "main property" details:
+            | attribute                  | value    |
+            | value                      | 250000.0 |
+            | main_home_equity_disregard | 100000.0 |
+            | transaction_allowance      | 7500.0   |
+            | assessed_equity            | 142500.0 |
+        And I should see the following "capital summary" details:
+            | attribute                           | value    |
+            | total_property                      | 142500.0 |
+            | subject_matter_of_dispute_disregard | 100000.0 |
+            | assessed_capital                    | 42500.0  |

--- a/features/disputed_assets/disputed_property.feature
+++ b/features/disputed_assets/disputed_property.feature
@@ -1,7 +1,7 @@
 Feature:
     "I have a property that is disputed"
 
-    Scenario: A SMOD property below the threshold is disregarded.
+    Scenario: A SMOD property where the value of the client's share of its equity is entirely disregarded
         Given I am undertaking a standard assessment with an applicant who receives passporting benefits
         And I add the following main property details for the current assessment:
             | value                     | 150000 |
@@ -22,7 +22,7 @@ Feature:
             | subject_matter_of_dispute_disregard | 45500.0 |
             | assessed_capital                    | 0.0     |
 
-    Scenario: SMOD is capped if the threshold is exceeded.
+    Scenario: The SMOD disregard is capped if the property is assessed as being worth more than £100k.
         Given I am undertaking a standard assessment with an applicant who receives passporting benefits
         And I add the following main property details for the current assessment:
             | value                     | 250000 |

--- a/features/step_definitions/api_request.rb
+++ b/features/step_definitions/api_request.rb
@@ -1,3 +1,17 @@
+Given("I am undertaking a standard assessment with an applicant who receives passporting benefits") do
+  @api_version = 5
+  response = submit_request(:post, "assessments", @api_version,
+                            { client_reference_id: "N/A", submission_date: "2022-05-10" })
+  @assessment_id = response["assessment_id"]
+  submit_request(:post, "assessments/#{@assessment_id}/applicant", @api_version,
+                 { applicant: { date_of_birth: "1979-12-20",
+                                involvement_type: "applicant",
+                                has_partner_opponent: false,
+                                receives_qualifying_benefit: true } })
+  submit_request(:post, "assessments/#{@assessment_id}/proceeding_types", @api_version,
+                 { "proceeding_types": [{ ccms_code: "DA001", client_involvement_type: "A" }] })
+end
+
 Given("I am using version {int} of the API") do |int|
   @api_version = int
 end
@@ -41,6 +55,11 @@ end
 Given("I add the following capital details for {string} in the current assessment:") do |string, table|
   data = { string.to_s => table.hashes.map { cast_values(_1) } }
   submit_request(:post, "assessments/#{@assessment_id}/capitals", @api_version, data)
+end
+
+Given("I add the following main property details for the current assessment:") do |table|
+  data = { "properties": { "main_home": cast_values(table.rows_hash) } }
+  submit_request(:post, "assessments/#{@assessment_id}/properties", @api_version, data)
 end
 
 Given("I add the following proceeding types in the current assessment:") do |table|

--- a/features/support/response_support_methods.rb
+++ b/features/support/response_support_methods.rb
@@ -2,9 +2,11 @@ RESPONSE_SECTION_MAPPINGS = {
   "v5" => {
     "assessment_result" => "result_summary.overall_result.result",
     "disposable_income_summary" => "result_summary.disposable_income",
+    "capital summary" => "result_summary.capital",
     "capital_lower_threshold" => "result_summary.capital.proceeding_types.0.lower_threshold",
     "gross_income_upper_threshold" => "result_summary.gross_income.proceeding_types.1.upper_threshold",
     "gross_income_proceeding_types" => "result_summary.gross_income.proceeding_types",
+    "main property" => "assessment.capital.capital_items.properties.main_home",
   },
 }.freeze
 

--- a/spec/services/calculators/subject_matter_of_dispute_disregard_calculator_spec.rb
+++ b/spec/services/calculators/subject_matter_of_dispute_disregard_calculator_spec.rb
@@ -3,11 +3,10 @@ require "rails_helper"
 module Calculators
   RSpec.describe SubjectMatterOfDisputeDisregardCalculator do
     subject(:value) do
-      described_class.new(submission_date: assessment.submission_date,
-                          capital_summary: assessment.capital_summary).value
+      described_class.new(capital_summary:,
+                          maximum_disregard:).value
     end
 
-    let(:assessment) { create :assessment, capital_summary: }
     let(:capital_summary) do
       create :capital_summary,
              vehicles: [vehicle],
@@ -17,11 +16,7 @@ module Calculators
     let(:vehicle) { create :vehicle, subject_matter_of_dispute: false }
     let(:capital_item) { create :liquid_capital_item, subject_matter_of_dispute: false }
     let(:property) { create :property, subject_matter_of_dispute: false }
-    let(:threshold_value) { 10_000 }
-
-    before do
-      allow(Threshold).to receive(:value_for).and_return(threshold_value)
-    end
+    let(:maximum_disregard) { 10_000 }
 
     describe "#value" do
       context "without any SMOD assets" do
@@ -74,11 +69,11 @@ module Calculators
         end
       end
 
-      context "if there is no valid threshold provided" do
+      context "if there is no valid upper limit provided" do
         let(:capital_item) { create :liquid_capital_item, value: 3_000, subject_matter_of_dispute: true }
         let(:vehicle) { create :vehicle, assessed_value: 1_000, subject_matter_of_dispute: true }
         let(:property) { create :property, assessed_equity: 9_000, subject_matter_of_dispute: true }
-        let(:threshold_value) { nil }
+        let(:maximum_disregard) { nil }
 
         it "raises an exception" do
           expect { value }.to raise_error RuntimeError

--- a/spec/services/collators/capital_collator_spec.rb
+++ b/spec/services/collators/capital_collator_spec.rb
@@ -15,7 +15,7 @@ module Collators
         described_class.call submission_date: assessment.submission_date,
                              capital_summary: assessment.capital_summary,
                              pensioner_capital_disregard: pcd_value,
-                             subject_matter_of_dispute_disregard: smod_value
+                             maximum_subject_matter_of_dispute_disregard: smod_value
       end
 
       it "always returns a hash" do
@@ -57,7 +57,6 @@ module Collators
 
       context "summarization of result_fields" do
         let(:pcd_value) { 100_000 }
-        let(:smod_value) { 5_000 }
 
         it "summarizes the results it gets from the subservices" do
           property_service = instance_double Calculators::PropertyCalculator
@@ -78,8 +77,8 @@ module Collators
           expect(collator[:total_mortgage_allowance]).to eq 999_999_999_999
           expect(collator[:total_capital]).to eq 26_145.83
           expect(collator[:pensioner_capital_disregard]).to eq 100_000
-          expect(collator[:subject_matter_of_dispute_disregard]).to eq 5_000
-          expect(collator[:assessed_capital]).to eq(-78_854.17)
+          expect(collator[:subject_matter_of_dispute_disregard]).to eq 0
+          expect(collator[:assessed_capital]).to eq(-73_854.17)
         end
       end
     end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/EL-515)

We were trying to sum the values of SMOD assets before we'd assessed the values of those assets, leading to incorrect calculations. This fixes that by moving the summing to later in the process.