### PR TITLE
remove call to run integration tests on main

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -344,7 +344,7 @@ workflows:
       - integration_tests:
           filters:
             branches:
-              ignore: main
+              only: main
       #          <<: *generic-slack-fail-post-stepa
       - check_swagger:
           filters:


### PR DESCRIPTION
## What

CircleCI was running the integration tests twice on non main branches. I have amended this so that the merge_pr workflow is only run on main (after a merge) and this includes the integration tests. If the tests were meant to be turned off for main we can achieve that by removing the call to the integration_test job from the merge_pr workflow.

Describe what you did and why.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
