### PR TITLE
EL-594: Return combined capital contribution

### DIFF
--- a/app/services/capital_collator_and_assessor.rb
+++ b/app/services/capital_collator_and_assessor.rb
@@ -17,9 +17,12 @@ class CapitalCollatorAndAssessor
         )
         assessment.partner_capital_summary.update!(partner_data)
         assessment.capital_summary.update!(combined_assessed_capital: assessment.capital_summary.assessed_capital +
-                                                                  assessment.partner_capital_summary.assessed_capital)
+                                                                        assessment.partner_capital_summary.assessed_capital,
+                                           combined_capital_contribution: assessment.capital_summary.capital_contribution +
+                                                                            assessment.partner_capital_summary.capital_contribution)
       else
-        assessment.capital_summary.update!(combined_assessed_capital: assessment.capital_summary.assessed_capital)
+        assessment.capital_summary.update!(combined_assessed_capital: assessment.capital_summary.assessed_capital,
+                                           combined_capital_contribution: assessment.capital_summary.capital_contribution)
       end
       Assessors::CapitalAssessor.call(assessment.capital_summary, assessment.capital_summary.combined_assessed_capital)
     end

--- a/app/services/decorators/v5/capital_result_decorator.rb
+++ b/app/services/decorators/v5/capital_result_decorator.rb
@@ -7,7 +7,7 @@ module Decorators
 
       def as_json
         if @summary.is_a?(ApplicantCapitalSummary)
-          basic_attributes.merge(proceeding_types:, combined_assessed_capital:)
+          basic_attributes.merge(proceeding_types:, combined_assessed_capital:, combined_capital_contribution:)
         else
           basic_attributes
         end
@@ -38,6 +38,10 @@ module Decorators
 
       def combined_assessed_capital
         summary.combined_assessed_capital.to_f
+      end
+
+      def combined_capital_contribution
+        summary.combined_capital_contribution.to_f
       end
     end
   end

--- a/app/services/decorators/v5/result_summary_decorator.rb
+++ b/app/services/decorators/v5/result_summary_decorator.rb
@@ -17,6 +17,7 @@ module Decorators
           overall_result: {
             result: @assessment.assessment_result,
             capital_contribution: capital_summary.capital_contribution.to_f,
+            combined_capital_contribution: capital_summary.combined_capital_contribution.to_f,
             income_contribution: disposable_income_summary.income_contribution.to_f,
             proceeding_types: ProceedingTypesResultDecorator.new(assessment).as_json,
           },

--- a/app/services/decorators/v5/result_summary_decorator.rb
+++ b/app/services/decorators/v5/result_summary_decorator.rb
@@ -16,8 +16,7 @@ module Decorators
         {
           overall_result: {
             result: @assessment.assessment_result,
-            capital_contribution: capital_summary.capital_contribution.to_f,
-            combined_capital_contribution: capital_summary.combined_capital_contribution.to_f,
+            capital_contribution: capital_summary.combined_capital_contribution.to_f,
             income_contribution: disposable_income_summary.income_contribution.to_f,
             proceeding_types: ProceedingTypesResultDecorator.new(assessment).as_json,
           },

--- a/db/migrate/20230104121138_add_combined_contributions_to_summaries.rb
+++ b/db/migrate/20230104121138_add_combined_contributions_to_summaries.rb
@@ -1,0 +1,5 @@
+class AddCombinedContributionsToSummaries < ActiveRecord::Migration[7.0]
+  def change
+    add_column :capital_summaries, :combined_capital_contribution, :decimal
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_11_28_152328) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_04_121138) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -84,6 +84,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_28_152328) do
     t.decimal "subject_matter_of_dispute_disregard", default: "0.0", null: false
     t.string "type", default: "ApplicantCapitalSummary"
     t.decimal "combined_assessed_capital"
+    t.decimal "combined_capital_contribution"
     t.index ["assessment_id"], name: "index_capital_summaries_on_assessment_id"
   end
 

--- a/features/partner/partner_assessment.feature
+++ b/features/partner/partner_assessment.feature
@@ -48,8 +48,8 @@ Feature:
     And I should see the following overall summary:
       | attribute                  | value                 |
       | assessment_result          | contribution_required |
-      | total income contribution  | 15.08                 |
-      | total capital contribution | 0.0                   |
+      | income contribution        | 15.08                 |
+      | capital contribution       | 0.0                   |
 
   Scenario: A applicant with a partner with capital and both pensioners
     Given I am undertaking a standard assessment with a pensioner applicant who is not passported
@@ -68,6 +68,6 @@ Feature:
     And I should see the following overall summary:
       | attribute                  | value                 |
       | assessment_result          | contribution_required |
-      | total income contribution  | 15.08                 |
-      | total capital contribution | 61900.0               |
+      | income contribution        | 15.08                 |
+      | capital contribution       | 61900.0               |
 

--- a/features/partner/partner_assessment.feature
+++ b/features/partner/partner_assessment.feature
@@ -46,8 +46,10 @@ Feature:
       | attribute                    | value    |
       | total_disposable_income      | 354.09   |
     And I should see the following overall summary:
-      | attribute                    | value                 |
-      | assessment_result            | contribution_required |
+      | attribute                  | value                 |
+      | assessment_result          | contribution_required |
+      | total income contribution  | 15.08                 |
+      | total capital contribution | 0.0                   |
 
   Scenario: A applicant with a partner with capital and both pensioners
     Given I am undertaking a standard assessment with a pensioner applicant who is not passported
@@ -64,6 +66,8 @@ Feature:
       | subject_matter_of_dispute   | false     |
     When I retrieve the final assessment
     And I should see the following overall summary:
-      | attribute                    | value                   |
-      | assessment_result            | contribution_required   |
+      | attribute                  | value                 |
+      | assessment_result          | contribution_required |
+      | total income contribution  | 15.08                 |
+      | total capital contribution | 61900.0               |
 

--- a/features/step_definitions/api_request.rb
+++ b/features/step_definitions/api_request.rb
@@ -127,7 +127,7 @@ Then("I should see the following overall summary:") do |table|
   end
 
   unless failures.empty?
-    failures.append "\n----\Response being validated: #{assessment.response.to_json}\n----\n"
+    failures.append "\n----\Response being validated: #{@response.to_json}\n----\n"
   end
 
   raise_if_present(failures)

--- a/features/support/response_support_methods.rb
+++ b/features/support/response_support_methods.rb
@@ -1,6 +1,8 @@
 RESPONSE_SECTION_MAPPINGS = {
   "v5" => {
     "assessment_result" => "result_summary.overall_result.result",
+    "total capital contribution" => "result_summary.overall_result.combined_capital_contribution",
+    "total income contribution" => "result_summary.overall_result.income_contribution",
     "disposable_income_summary" => "result_summary.disposable_income",
     "capital summary" => "result_summary.capital",
     "capital_lower_threshold" => "result_summary.capital.proceeding_types.0.lower_threshold",

--- a/features/support/response_support_methods.rb
+++ b/features/support/response_support_methods.rb
@@ -1,8 +1,8 @@
 RESPONSE_SECTION_MAPPINGS = {
   "v5" => {
     "assessment_result" => "result_summary.overall_result.result",
-    "total capital contribution" => "result_summary.overall_result.combined_capital_contribution",
-    "total income contribution" => "result_summary.overall_result.income_contribution",
+    "capital contribution" => "result_summary.overall_result.capital_contribution",
+    "income contribution" => "result_summary.overall_result.income_contribution",
     "disposable_income_summary" => "result_summary.disposable_income",
     "capital summary" => "result_summary.capital",
     "capital_lower_threshold" => "result_summary.capital.proceeding_types.0.lower_threshold",

--- a/spec/services/decorators/v5/capital_result_decorator_spec.rb
+++ b/spec/services/decorators/v5/capital_result_decorator_spec.rb
@@ -57,6 +57,7 @@ module Decorators
             },
           ],
           combined_assessed_capital: 12_000.0,
+          combined_capital_contribution: 0,
         }
       end
 


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/EL-594)

While income contribution is calculated as a single value that already takes into account partner income/outgoing, we currently have separate capital contribution values for applicant and partner, and only the former is being returned in the calculation result. This PR adds a place to store the combined value, and logic to return it to the client.

[EL-594]: https://dsdmoj.atlassian.net/browse/EL-594?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ