### PR TITLE
Fix Copy-N-paste error in circle config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -344,7 +344,7 @@ workflows:
       - integration_tests:
           filters:
             branches:
-              ignore: main
+              only: main
       #          <<: *generic-slack-fail-post-stepa
       - check_swagger:
           filters:


### PR DESCRIPTION
Circle:CI is running the wrong tests on branches due to a copy-and-paste error in the config
