### PR TITLE
EL-621: Move partner allowance from partner to applicant

### DIFF
--- a/app/services/decorators/v5/disposable_income_result_decorator.rb
+++ b/app/services/decorators/v5/disposable_income_result_decorator.rb
@@ -1,16 +1,20 @@
 module Decorators
   module V5
     class DisposableIncomeResultDecorator
-      def initialize(summary, gross_income_summary)
+      def initialize(summary, gross_income_summary, partner_present:)
         @summary = summary
         @gross_income_summary = gross_income_summary
+        @partner_present = partner_present
       end
 
       def as_json
         if summary.is_a?(ApplicantDisposableIncomeSummary)
-          basic_attributes.merge(proceeding_types:, combined_total_disposable_income:, combined_total_outgoings_and_allowances:)
+          basic_attributes.merge(proceeding_types:,
+                                 combined_total_disposable_income:,
+                                 combined_total_outgoings_and_allowances:,
+                                 partner_allowance:)
         else
-          basic_attributes.merge(partner_allowance:)
+          basic_attributes
         end
       end
 
@@ -52,6 +56,8 @@ module Decorators
       end
 
       def partner_allowance
+        return 0 unless @partner_present
+
         Threshold.value_for(:partner_allowance, at: @summary.assessment.submission_date)
       end
 

--- a/app/services/decorators/v5/result_summary_decorator.rb
+++ b/app/services/decorators/v5/result_summary_decorator.rb
@@ -23,7 +23,8 @@ module Decorators
           gross_income: GrossIncomeResultDecorator.new(gross_income_summary).as_json,
           partner_gross_income:,
           disposable_income: DisposableIncomeResultDecorator.new(disposable_income_summary,
-                                                                 gross_income_summary).as_json,
+                                                                 gross_income_summary,
+                                                                 partner_present: assessment.partner.present?).as_json,
           partner_disposable_income:,
           capital: CapitalResultDecorator.new(capital_summary).as_json,
           partner_capital:,
@@ -40,7 +41,8 @@ module Decorators
         return unless assessment.partner
 
         DisposableIncomeResultDecorator.new(assessment.partner_disposable_income_summary,
-                                            assessment.partner_gross_income_summary).as_json
+                                            assessment.partner_gross_income_summary,
+                                            partner_present: true).as_json
       end
 
       def partner_capital

--- a/spec/services/decorators/v5/disposable_income_result_decorator_spec.rb
+++ b/spec/services/decorators/v5/disposable_income_result_decorator_spec.rb
@@ -31,7 +31,7 @@ module Decorators
         }
       end
       let(:proceeding_hash) { [%w[DA003 A], %w[DA005 A], %w[SE003 A], %w[SE014 A]] }
-
+      let(:partner_present) { true }
       let(:expected_result) do
         {
           dependant_allowance: 220.21,
@@ -83,10 +83,11 @@ module Decorators
           ],
           combined_total_disposable_income: 900.0,
           combined_total_outgoings_and_allowances: 400.32,
+          partner_allowance: 191.41,
         }
       end
 
-      subject(:decorator) { described_class.new(summary, assessment.gross_income_summary).as_json }
+      subject(:decorator) { described_class.new(summary, assessment.gross_income_summary, partner_present:).as_json }
 
       before do
         pt_results.each do |ptc, details|


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/EL-621)

Moved it so that we list the partner allowance on the applicant's disposable income summary rather than the partner's disposable income summary (but we only show it above zero if the client actually has a partner)

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
