### PR TITLE
EL-632 property controlled work calculation

### DIFF
--- a/app/models/property.rb
+++ b/app/models/property.rb
@@ -7,6 +7,7 @@ class Property < ApplicationRecord
 
   delegate :assessment, to: :capital_summary
   delegate :submission_date, to: :assessment
+  delegate :level_of_representation, to: :assessment
 
   def assess_equity!(remaining_mortgage_allowance)
     calculate_property_transaction_allowance
@@ -25,7 +26,7 @@ private
   end
 
   def notional_transaction_cost_pctg
-    Threshold.value_for(:property_notional_sale_costs_percentage, at: submission_date) / 100.0
+    level_of_representation == :controlled ? 0.0 : Threshold.value_for(:property_notional_sale_costs_percentage, at: submission_date) / 100.0
   end
 
   def calculate_outstanding_mortgage(remaining_mortgage_allowance)

--- a/app/models/property.rb
+++ b/app/models/property.rb
@@ -22,11 +22,12 @@ class Property < ApplicationRecord
 private
 
   def calculate_property_transaction_allowance
-    self.transaction_allowance = (value * notional_transaction_cost_pctg).round(2)
+    allowance = level_of_representation == "controlled" ? 0 : (value * notional_transaction_cost_pctg).round(2)
+    self.transaction_allowance = allowance
   end
 
   def notional_transaction_cost_pctg
-    level_of_representation == :controlled ? 0.0 : Threshold.value_for(:property_notional_sale_costs_percentage, at: submission_date) / 100.0
+    Threshold.value_for(:property_notional_sale_costs_percentage, at: submission_date) / 100.0
   end
 
   def calculate_outstanding_mortgage(remaining_mortgage_allowance)

--- a/features/controlled_work/property_assessment.feature
+++ b/features/controlled_work/property_assessment.feature
@@ -1,0 +1,22 @@
+Feature:
+  "Applicant is applying under controlled work and has a property so costs of sale (transaction_allowance) are not included"
+
+  Scenario: An applicant has property and sale costs are not disregarded
+    Given I am undertaking a controlled work assessment with an applicant who receives passporting benefits
+    And I add the following main property details for the current assessment:
+      | value                     | 163000 |
+      | outstanding_mortgage      | 13000  |
+      | percentage_owned          | 100    |
+      | shared_with_housing_assoc | false  |
+      | subject_matter_of_dispute | false  |
+    When I retrieve the final assessment
+    Then I should see the following "main property" details:
+      | attribute                  | value    |
+      | value                      | 163000.0 |
+      | main_home_equity_disregard | 100000.0 |
+      | transaction_allowance      | 0.0      |
+      | assessed_equity            | 50000.0  |
+    And I should see the following overall summary:
+      | attribute                  | value                 |
+      | assessment_result          | contribution_required |
+

--- a/features/step_definitions/api_request.rb
+++ b/features/step_definitions/api_request.rb
@@ -27,6 +27,20 @@ Given("I am undertaking a standard assessment with a pensioner applicant who is 
                  { "proceeding_types": [{ ccms_code: "DA001", client_involvement_type: "A" }] })
 end
 
+Given("I am undertaking a controlled work assessment with an applicant who receives passporting benefits") do
+  @api_version = 5
+  response = submit_request(:post, "assessments", @api_version,
+                            { client_reference_id: "N/A", submission_date: "2022-05-10", level_of_representation: "controlled" })
+  @assessment_id = response["assessment_id"]
+  submit_request(:post, "assessments/#{@assessment_id}/applicant", @api_version,
+                 { applicant: { date_of_birth: "1979-12-20",
+                                involvement_type: "applicant",
+                                has_partner_opponent: false,
+                                receives_qualifying_benefit: true } })
+  submit_request(:post, "assessments/#{@assessment_id}/proceeding_types", @api_version,
+                 { "proceeding_types": [{ ccms_code: "DA001", client_involvement_type: "A" }] })
+end
+
 Given("I am using version {int} of the API") do |int|
   @api_version = int
 end


### PR DESCRIPTION
Based on Patricks el-361 branch so do not review until that has been merged
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-632)


Add a check for controlled work before transaction allowance is calculated for property
Add a cucumber test to ensure the transaction_allowance for controlled work assessments is always zero

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
