### PR TITLE
EL-604 Add tests (and fixes where appropriate) for all capital items

### DIFF
--- a/app/services/decorators/v5/capital_item_decorator.rb
+++ b/app/services/decorators/v5/capital_item_decorator.rb
@@ -8,7 +8,7 @@ module Decorators
       def as_json
         {
           description: @record.description,
-          value: @record.value,
+          value: @record.value.to_f,
         }
       end
     end

--- a/app/services/decorators/v5/property_decorator.rb
+++ b/app/services/decorators/v5/property_decorator.rb
@@ -13,17 +13,17 @@ module Decorators
 
       def payload
         {
-          value: @record.value,
-          outstanding_mortgage: @record.outstanding_mortgage,
-          percentage_owned: @record.percentage_owned,
+          value: @record.value.to_f,
+          outstanding_mortgage: @record.outstanding_mortgage.to_f,
+          percentage_owned: @record.percentage_owned.to_f,
           main_home: @record.main_home,
           shared_with_housing_assoc: @record.shared_with_housing_assoc,
-          transaction_allowance: @record.transaction_allowance,
-          allowable_outstanding_mortgage: @record.allowable_outstanding_mortgage,
-          net_value: @record.net_value,
-          net_equity: @record.net_equity,
-          main_home_equity_disregard: @record.main_home_equity_disregard,
-          assessed_equity: @record.assessed_equity,
+          transaction_allowance: @record.transaction_allowance.to_f,
+          allowable_outstanding_mortgage: @record.allowable_outstanding_mortgage.to_f,
+          net_value: @record.net_value.to_f,
+          net_equity: @record.net_equity.to_f,
+          main_home_equity_disregard: @record.main_home_equity_disregard.to_f,
+          assessed_equity: @record.assessed_equity.to_f,
         }
       end
     end


### PR DESCRIPTION
https://dsdmoj.atlassian.net/browse/EL-604

Whilst working on EL-604, it was discovered that several capital items (mainly property) had many of their numeric fields returned as strings in the CFE payload. This  introduces higher-level tests for all capital items, and adds fixes for the property and liquid/non-liquid assets fields.