### PR TITLE
employment calculator returns answer

### DIFF
--- a/app/services/calculators/employment_income_calculator.rb
+++ b/app/services/calculators/employment_income_calculator.rb
@@ -1,14 +1,12 @@
 module Calculators
   class EmploymentIncomeCalculator
-    def self.call(submission_date:, employment:, disposable_income_summary:, gross_income_summary:)
-      new(submission_date:, employment:, disposable_income_summary:, gross_income_summary:).call
+    def self.call(submission_date:, employment:)
+      new(submission_date:, employment:).call
     end
 
-    def initialize(submission_date:, employment:, disposable_income_summary:, gross_income_summary:)
+    def initialize(submission_date:, employment:)
       @submission_date = submission_date
       @employment = employment
-      @disposable_income_summary = disposable_income_summary
-      @gross_income_summary = gross_income_summary
     end
 
     def call
@@ -18,14 +16,14 @@ module Calculators
   private
 
     def process_single_employment
-      @employment&.calculate!
+      @employment&.calculate! @submission_date
 
-      @gross_income_summary.update!(gross_employment_income:,
-                                    benefits_in_kind: monthly_benefits_in_kind)
-      @disposable_income_summary.update!(employment_income_deductions: deductions,
-                                         fixed_employment_allowance: allowance,
-                                         tax: taxes,
-                                         national_insurance: ni_contributions)
+      EmploymentIncomeResult.new(gross_employment_income:,
+                                 benefits_in_kind: monthly_benefits_in_kind,
+                                 employment_income_deductions: deductions,
+                                 fixed_employment_allowance: allowance,
+                                 tax: taxes,
+                                 national_insurance: ni_contributions).freeze
     end
 
     def gross_employment_income

--- a/app/services/calculators/employment_income_result.rb
+++ b/app/services/calculators/employment_income_result.rb
@@ -1,0 +1,4 @@
+module Calculators
+  EmploymentIncomeResult = Struct.new :gross_employment_income, :benefits_in_kind, :employment_income_deductions,
+                                      :fixed_employment_allowance, :tax, :national_insurance, keyword_init: true
+end

--- a/app/services/collators/disposable_income_collator.rb
+++ b/app/services/collators/disposable_income_collator.rb
@@ -15,8 +15,7 @@ module Collators
              :fixed_employment_allowance,
              :employment_income_deductions, to: :@disposable_income_summary
 
-    delegate :total_gross_income,
-             :gross_employment_income, to: :@gross_income_summary
+    delegate :total_gross_income, to: :@gross_income_summary
 
     class << self
       def call(disposable_income_summary:, gross_income_summary:, partner_allowance:)

--- a/app/services/utilities/employment_income_variation_checker.rb
+++ b/app/services/utilities/employment_income_variation_checker.rb
@@ -1,22 +1,18 @@
 module Utilities
   class EmploymentIncomeVariationChecker
-    def initialize(employment)
-      @employment = employment
+    def initialize(employment_payments)
+      @employment_payments = employment_payments
     end
 
-    def below_threshold?
+    def below_threshold?(submission_date)
       variance < Threshold.value_for(:employment_income_variance, at: submission_date)
     end
 
   private
 
     def variance
-      amounts = @employment.employment_payments.map(&:gross_income_monthly_equiv)
+      amounts = @employment_payments.map(&:gross_income_monthly_equiv)
       (amounts.max - amounts.min)
-    end
-
-    def submission_date
-      @employment.assessment.submission_date
     end
   end
 end

--- a/spec/models/employment_spec.rb
+++ b/spec/models/employment_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Employment do
     it "calls the tax and national insurance refund calculator" do
       allow(Calculators::TaxNiRefundCalculator).to receive(:call)
 
-      employment.calculate!
+      employment.calculate! employment.assessment.submission_date
 
       expect(Calculators::TaxNiRefundCalculator)
         .to have_received(:call)
@@ -48,7 +48,7 @@ RSpec.describe Employment do
 
         it "updates the monthly gross income, national insurance, and tax to " \
            "the most recent payment" do
-          employment.calculate!
+          employment.calculate! employment.assessment.submission_date
 
           expect(employment).to have_attributes(
             calculation_method: "most_recent",
@@ -59,7 +59,7 @@ RSpec.describe Employment do
         end
 
         it "does not add a remark to the assessment" do
-          employment.calculate!
+          employment.calculate! employment.assessment.submission_date
 
           remarks = employment.assessment.remarks.remarks_hash
           expect(remarks).to be_blank
@@ -79,7 +79,7 @@ RSpec.describe Employment do
 
         it "updates the monthly gross income, national insurance, and tax to " \
            "the blunt average" do
-          employment.calculate!
+          employment.calculate! employment.assessment.submission_date
 
           expect(employment).to have_attributes(
             calculation_method: "blunt_average",
@@ -90,7 +90,7 @@ RSpec.describe Employment do
         end
 
         it "adds a remark to the assessment" do
-          employment.calculate!
+          employment.calculate! employment.assessment.submission_date
 
           remarks = employment.assessment.remarks.remarks_hash
           employment_payments = employment.employment_payments
@@ -102,7 +102,7 @@ RSpec.describe Employment do
 
     context "when there are no employment payments" do
       it "zeros the monthly gross income, national insurance, and tax" do
-        employment.calculate!
+        employment.calculate! employment.assessment.submission_date
 
         expect(employment).to have_attributes(
           calculation_method: "blunt_average",

--- a/spec/services/calculators/employment_income_calculator_spec.rb
+++ b/spec/services/calculators/employment_income_calculator_spec.rb
@@ -3,7 +3,6 @@ require "rails_helper"
 module Calculators
   RSpec.describe EmploymentIncomeCalculator, :vcr do
     let(:assessment) { create :assessment, gross_income_summary: build(:gross_income_summary) }
-    let!(:disposable_income_summary) { create :disposable_income_summary, assessment: }
     let(:employment1) { create :employment, assessment: }
     let(:employment2) { create :employment, assessment: }
     let(:gross) { BigDecimal(rand(2022.35...3096.52), 2) }
@@ -24,17 +23,13 @@ module Calculators
       it "does not call the Multiple Employments Calculator" do
         allow(employment1).to receive(:calculate!)
         described_class.call(submission_date: assessment.submission_date,
-                             employment: employment1,
-                             disposable_income_summary: assessment.disposable_income_summary,
-                             gross_income_summary: assessment.gross_income_summary)
+                             employment: employment1)
       end
 
       it "calls #calculate! on each employment record" do
         expect(employment1).to receive(:calculate!)
         described_class.call(submission_date: assessment.submission_date,
-                             employment: employment1,
-                             disposable_income_summary: assessment.disposable_income_summary,
-                             gross_income_summary: assessment.gross_income_summary)
+                             employment: employment1)
       end
     end
 
@@ -42,21 +37,15 @@ module Calculators
       context "at least one employment record exists" do
         it "adds the fixed employment allowance from the threshold files" do
           create_payments_for_single_employment
-          described_class.call(submission_date: assessment.submission_date,
-                               employment: assessment.employments.first,
-                               disposable_income_summary: assessment.disposable_income_summary,
-                               gross_income_summary: assessment.gross_income_summary)
-          expect(disposable_income_summary.fixed_employment_allowance).to eq(-45)
+          expect(described_class.call(submission_date: assessment.submission_date,
+                                      employment: assessment.employments.first).fixed_employment_allowance).to eq(-45)
         end
       end
 
       context "no employment records exist" do
         it "leaves the fixed employment allowance as zero" do
-          described_class.call(submission_date: assessment.submission_date,
-                               employment: assessment.employments.first,
-                               disposable_income_summary: assessment.disposable_income_summary,
-                               gross_income_summary: assessment.gross_income_summary)
-          expect(disposable_income_summary.fixed_employment_allowance).to eq 0.0
+          expect(described_class.call(submission_date: assessment.submission_date,
+                                      employment: assessment.employments.first).fixed_employment_allowance).to eq 0.0
         end
       end
     end

--- a/spec/services/calculators/multiple_employments_calculator_spec.rb
+++ b/spec/services/calculators/multiple_employments_calculator_spec.rb
@@ -9,51 +9,33 @@ module Calculators
     end
 
     it "sets gross employment income to zero" do
-      described_class.call(assessment:,
-                           employments: assessment.employments,
-                           disposable_income_summary: assessment.disposable_income_summary,
-                           gross_income_summary: assessment.gross_income_summary)
-      expect(assessment.gross_income_summary.gross_employment_income).to eq 0
+      expect(described_class.call(assessment:,
+                                  employments: assessment.employments).gross_employment_income).to eq 0
     end
 
     it "sets benefits in kind to zero" do
-      described_class.call(assessment:,
-                           employments: assessment.employments,
-                           disposable_income_summary: assessment.disposable_income_summary,
-                           gross_income_summary: assessment.gross_income_summary)
-      expect(assessment.gross_income_summary.benefits_in_kind).to eq 0
+      expect(described_class.call(assessment:,
+                                  employments: assessment.employments).benefits_in_kind).to eq 0
     end
 
     it "sets employment income deductions to zero" do
-      described_class.call(assessment:,
-                           employments: assessment.employments,
-                           disposable_income_summary: assessment.disposable_income_summary,
-                           gross_income_summary: assessment.gross_income_summary)
-      expect(assessment.disposable_income_summary.employment_income_deductions).to eq 0
+      expect(described_class.call(assessment:,
+                                  employments: assessment.employments).employment_income_deductions).to eq 0
     end
 
     it "sets tax to zero" do
-      described_class.call(assessment:,
-                           employments: assessment.employments,
-                           disposable_income_summary: assessment.disposable_income_summary,
-                           gross_income_summary: assessment.gross_income_summary)
-      expect(assessment.disposable_income_summary.tax).to eq 0
+      expect(described_class.call(assessment:,
+                                  employments: assessment.employments).tax).to eq 0
     end
 
     it "sets national insurance to zero" do
-      described_class.call(assessment:,
-                           employments: assessment.employments,
-                           disposable_income_summary: assessment.disposable_income_summary,
-                           gross_income_summary: assessment.gross_income_summary)
-      expect(assessment.disposable_income_summary.national_insurance).to eq 0
+      expect(described_class.call(assessment:,
+                                  employments: assessment.employments).national_insurance).to eq 0
     end
 
     it "sets fixed employment allowance to 45" do
-      described_class.call(assessment:,
-                           employments: assessment.employments,
-                           disposable_income_summary: assessment.disposable_income_summary,
-                           gross_income_summary: assessment.gross_income_summary)
-      expect(assessment.disposable_income_summary.fixed_employment_allowance).to eq(-45)
+      expect(described_class.call(assessment:,
+                                  employments: assessment.employments).fixed_employment_allowance).to eq(-45)
     end
   end
 end

--- a/spec/services/decorators/v5/disposable_income_result_decorator_spec.rb
+++ b/spec/services/decorators/v5/disposable_income_result_decorator_spec.rb
@@ -106,10 +106,14 @@ module Decorators
         it "returns the expected structure" do
           employment1
           employment2
-          Calculators::MultipleEmploymentsCalculator.call(assessment:,
-                                                          employments: assessment.employments,
-                                                          disposable_income_summary: assessment.disposable_income_summary,
-                                                          gross_income_summary: assessment.gross_income_summary)
+          result = Calculators::MultipleEmploymentsCalculator.call(assessment:,
+                                                                   employments: assessment.employments)
+          assessment.gross_income_summary.update!(gross_employment_income: result.gross_employment_income,
+                                                  benefits_in_kind: result.benefits_in_kind)
+          assessment.disposable_income_summary.update!(employment_income_deductions: result.employment_income_deductions,
+                                                       fixed_employment_allowance: result.fixed_employment_allowance,
+                                                       tax: result.tax,
+                                                       national_insurance: result.national_insurance)
 
           expect(decorator).to eq expected_result
         end

--- a/spec/services/utilities/employment_income_variation_checker_spec.rb
+++ b/spec/services/utilities/employment_income_variation_checker_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 module Utilities
   RSpec.describe EmploymentIncomeVariationChecker do
     let(:employment) { create :employment }
-    let(:result) { described_class.new(employment).below_threshold? }
+    let(:result) { described_class.new(employment.employment_payments).below_threshold?(employment.assessment.submission_date) }
 
     before do
       amounts.each do |amount|


### PR DESCRIPTION
This is a product of the 'functional spike' specifically around the 'Employment Calculator' class(es) which now return an answer (which the upper layer saves to the database) rathe than having the side effect of saving to the database themselves. 

This makes the classes easier to reason about, removes 2 dependencies and also has the side effect of removing duplication - as it turned out both calculators did the database save, whereas now only the (1) higher level has to perform the save.