### PR TITLE
EL-657: Move vehicle total out of the DB

### DIFF
--- a/app/controllers/assessments_controller.rb
+++ b/app/controllers/assessments_controller.rb
@@ -29,8 +29,8 @@ private
   end
 
   def perform_assessment
-    Workflows::MainWorkflow.call(assessment)
-    render json: decorator_klass.new(assessment).as_json
+    calculation_output = Workflows::MainWorkflow.call(assessment)
+    render json: decorator_klass.new(assessment, calculation_output).as_json
   end
 
   def version

--- a/app/lib/calculation_output.rb
+++ b/app/lib/calculation_output.rb
@@ -1,7 +1,7 @@
 class CalculationOutput
-  def initialize(capital_collation:)
-    @capital_collation = capital_collation
+  def initialize(capital_subtotals:)
+    @capital_subtotals = capital_subtotals
   end
 
-  attr_reader :capital_collation
+  attr_reader :capital_subtotals
 end

--- a/app/lib/calculation_output.rb
+++ b/app/lib/calculation_output.rb
@@ -1,0 +1,7 @@
+class CalculationOutput
+  def initialize(capital_collation:)
+    @capital_collation = capital_collation
+  end
+
+  attr_reader :capital_collation
+end

--- a/app/lib/calculation_output.rb
+++ b/app/lib/calculation_output.rb
@@ -1,5 +1,5 @@
 class CalculationOutput
-  def initialize(capital_subtotals:)
+  def initialize(capital_subtotals: CapitalSubtotals.new)
     @capital_subtotals = capital_subtotals
   end
 

--- a/app/lib/capital_subtotals.rb
+++ b/app/lib/capital_subtotals.rb
@@ -1,0 +1,8 @@
+class CapitalSubtotals
+  def initialize(applicant_capital_subtotals: PersonCapitalSubtotals.new, partner_capital_subtotals: PersonCapitalSubtotals.new)
+    @applicant_capital_subtotals = applicant_capital_subtotals
+    @partner_capital_subtotals = partner_capital_subtotals
+  end
+
+  attr_reader :applicant_capital_subtotals, :partner_capital_subtotals
+end

--- a/app/lib/person_capital_subtotals.rb
+++ b/app/lib/person_capital_subtotals.rb
@@ -1,0 +1,7 @@
+class PersonCapitalSubtotals
+  def initialize(total_vehicle: nil)
+    @total_vehicle = total_vehicle
+  end
+
+  attr_reader :total_vehicle
+end

--- a/app/models/vehicle.rb
+++ b/app/models/vehicle.rb
@@ -7,39 +7,4 @@ class Vehicle < ApplicationRecord
   validates :date_of_purchase, cfe_date: { not_in_the_future: true }
 
   scope :disputed, -> { where(subject_matter_of_dispute: true) }
-
-  def assess!
-    in_regular_use? ? assess_vehicle_in_regular_use : assess_vehicle_not_in_regular_use
-    save!
-  end
-
-private
-
-  def assess_vehicle_not_in_regular_use
-    self.included_in_assessment = true
-    self.assessed_value = value
-  end
-
-  def assess_vehicle_in_regular_use
-    net_value = value - loan_amount_outstanding
-    if vehicle_age_in_months >= vehicle_out_of_scope_age || net_value <= vehicle_disregard
-      self.included_in_assessment = false
-      self.assessed_value = 0
-    else
-      self.included_in_assessment = true
-      self.assessed_value = net_value - vehicle_disregard
-    end
-  end
-
-  def vehicle_age_in_months
-    Calculators::VehicleAgeCalculator.new(date_of_purchase, submission_date).in_months
-  end
-
-  def vehicle_out_of_scope_age
-    Threshold.value_for(:vehicle_out_of_scope_months, at: submission_date)
-  end
-
-  def vehicle_disregard
-    Threshold.value_for(:vehicle_disregard, at: submission_date)
-  end
 end

--- a/app/services/assessors/vehicle_assessor.rb
+++ b/app/services/assessors/vehicle_assessor.rb
@@ -1,9 +1,55 @@
 module Assessors
   class VehicleAssessor
+    Result = Struct.new(:value, :included_in_assessment)
     class << self
-      def call(vehicles)
-        vehicles.each(&:assess!)
-        vehicles.sum(&:assessed_value)
+      def call(vehicles, submission_date)
+        vehicles.sum { assess(_1, submission_date) }
+      end
+
+      def assess(vehicle, submission_date)
+        result = if vehicle.in_regular_use?
+                   assess_in_regular_use(vehicle, submission_date)
+                 else
+                   assess_not_in_regular_use(vehicle)
+                 end
+        save_assessed_value(vehicle, result)
+        result.value
+      end
+
+    private
+
+      def assess_in_regular_use(vehicle, submission_date)
+        net_value = vehicle.value - vehicle.loan_amount_outstanding
+        if too_old_to_count(vehicle, submission_date) || net_value <= vehicle_disregard(submission_date)
+          Result.new(0, false)
+        else
+          Result.new(net_value - vehicle_disregard(submission_date), true)
+        end
+      end
+
+      def assess_not_in_regular_use(vehicle)
+        Result.new(vehicle.value, true)
+      end
+
+      def too_old_to_count(vehicle, submission_date)
+        age_in_months(vehicle, submission_date) >= vehicle_out_of_scope_age(submission_date)
+      end
+
+      # TODO: remove this side effect
+      def save_assessed_value(vehicle, result)
+        vehicle.update!(assessed_value: result.value, included_in_assessment: result.included_in_assessment)
+      end
+
+      def age_in_months(vehicle, submission_date)
+        Calculators::VehicleAgeCalculator.new(vehicle.date_of_purchase, submission_date).in_months
+      end
+
+      def vehicle_out_of_scope_age(submission_date)
+        Threshold.value_for(:vehicle_out_of_scope_months, at: submission_date)
+      end
+
+      def vehicle_disregard(submission_date)
+        Threshold.value_for(:vehicle_disregard, at: submission_date)
       end
     end
   end

--- a/app/services/assessors/vehicle_assessor.rb
+++ b/app/services/assessors/vehicle_assessor.rb
@@ -1,6 +1,6 @@
 module Assessors
   class VehicleAssessor
-    Result = Struct.new(:value, :included_in_assessment)
+    Result = Struct.new(:value, :included_in_assessment, keyword_init: true)
     class << self
       def call(vehicles, submission_date)
         vehicles.sum { assess(_1, submission_date) }
@@ -21,14 +21,14 @@ module Assessors
       def assess_in_regular_use(vehicle, submission_date)
         net_value = vehicle.value - vehicle.loan_amount_outstanding
         if too_old_to_count(vehicle, submission_date) || net_value <= vehicle_disregard(submission_date)
-          Result.new(0, false)
+          Result.new(value: 0, included_in_assessment: false)
         else
-          Result.new(net_value - vehicle_disregard(submission_date), true)
+          Result.new(value: net_value - vehicle_disregard(submission_date), included_in_assessment: true)
         end
       end
 
       def assess_not_in_regular_use(vehicle)
-        Result.new(vehicle.value, true)
+        Result.new(value: vehicle.value, included_in_assessment: true)
       end
 
       def too_old_to_count(vehicle, submission_date)

--- a/app/services/capital_collator_and_assessor.rb
+++ b/app/services/capital_collator_and_assessor.rb
@@ -1,6 +1,6 @@
 class CapitalCollatorAndAssessor
-  PersonCapitalCollation = Struct.new(:total_vehicle)
-  CapitalCollation = Struct.new(:applicant_capital_collation, :partner_capital_collation)
+  PersonCapitalSubtotals = Struct.new(:total_vehicle, keyword_init: true)
+  CapitalSubtotals = Struct.new(:applicant_capital_subtotals, :partner_capital_subtotals, keyword_init: true)
   class << self
     def call(assessment)
       data = collate_applicant_capital(assessment)
@@ -14,9 +14,9 @@ class CapitalCollatorAndAssessor
         assessment.capital_summary.update!(combined_assessed_capital: assessment.capital_summary.assessed_capital)
       end
       Assessors::CapitalAssessor.call(assessment.capital_summary, assessment.capital_summary.combined_assessed_capital)
-      CapitalCollation.new(
-        PersonCapitalCollation.new(data[:total_vehicle]),
-        (PersonCapitalCollation.new(partner_data[:total_vehicle]) if assessment.partner.present?),
+      CapitalSubtotals.new(
+        applicant_capital_subtotals: PersonCapitalSubtotals.new(total_vehicle: data[:total_vehicle]),
+        partner_capital_subtotals: (PersonCapitalSubtotals.new(total_vehicle: partner_data[:total_vehicle]) if assessment.partner.present?),
       )
     end
 

--- a/app/services/capital_collator_and_assessor.rb
+++ b/app/services/capital_collator_and_assessor.rb
@@ -1,30 +1,44 @@
 class CapitalCollatorAndAssessor
+  PersonCapitalCollation = Struct.new(:total_vehicle)
+  CapitalCollation = Struct.new(:applicant_capital_collation, :partner_capital_collation)
   class << self
     def call(assessment)
-      data = Collators::CapitalCollator.call(
-        submission_date: assessment.submission_date,
-        capital_summary: assessment.capital_summary,
-        maximum_subject_matter_of_dispute_disregard: maximum_subject_matter_of_dispute_disregard(assessment),
-        pensioner_capital_disregard: pensioner_capital_disregard(assessment),
-      )
-      assessment.capital_summary.update!(data)
+      data = collate_applicant_capital(assessment)
+      assessment.capital_summary.update!(data.except(:total_vehicle))
       if assessment.partner.present?
-        partner_data = Collators::CapitalCollator.call(
-          submission_date: assessment.submission_date,
-          capital_summary: assessment.partner_capital_summary,
-          pensioner_capital_disregard: 0,
-          maximum_subject_matter_of_dispute_disregard: 0,
-        )
-        assessment.partner_capital_summary.update!(partner_data)
+        partner_data = collate_partner_capital(assessment)
+        assessment.partner_capital_summary.update!(partner_data.except(:total_vehicle))
         assessment.capital_summary.update!(combined_assessed_capital: assessment.capital_summary.assessed_capital +
                                                                         assessment.partner_capital_summary.assessed_capital)
       else
         assessment.capital_summary.update!(combined_assessed_capital: assessment.capital_summary.assessed_capital)
       end
       Assessors::CapitalAssessor.call(assessment.capital_summary, assessment.capital_summary.combined_assessed_capital)
+      CapitalCollation.new(
+        PersonCapitalCollation.new(data[:total_vehicle]),
+        (PersonCapitalCollation.new(partner_data[:total_vehicle]) if assessment.partner.present?),
+      )
     end
 
   private
+
+    def collate_applicant_capital(assessment)
+      Collators::CapitalCollator.call(
+        submission_date: assessment.submission_date,
+        capital_summary: assessment.capital_summary,
+        maximum_subject_matter_of_dispute_disregard: maximum_subject_matter_of_dispute_disregard(assessment),
+        pensioner_capital_disregard: pensioner_capital_disregard(assessment),
+      )
+    end
+
+    def collate_partner_capital(assessment)
+      Collators::CapitalCollator.call(
+        submission_date: assessment.submission_date,
+        capital_summary: assessment.partner_capital_summary,
+        pensioner_capital_disregard: 0,
+        maximum_subject_matter_of_dispute_disregard: 0,
+      )
+    end
 
     def total_disposable_income(assessment)
       if assessment.partner.present?

--- a/app/services/capital_collator_and_assessor.rb
+++ b/app/services/capital_collator_and_assessor.rb
@@ -1,6 +1,4 @@
 class CapitalCollatorAndAssessor
-  PersonCapitalSubtotals = Struct.new(:total_vehicle, keyword_init: true)
-  CapitalSubtotals = Struct.new(:applicant_capital_subtotals, :partner_capital_subtotals, keyword_init: true)
   class << self
     def call(assessment)
       data = collate_applicant_capital(assessment)

--- a/app/services/collators/capital_collator.rb
+++ b/app/services/collators/capital_collator.rb
@@ -36,7 +36,7 @@ module Collators
       @liquid_capital = Assessors::LiquidCapitalAssessor.call(@capital_summary)
       @non_liquid_capital = Assessors::NonLiquidCapitalAssessor.call(@capital_summary)
       @property = Calculators::PropertyCalculator.call(submission_date: @submission_date, capital_summary: @capital_summary)
-      @vehicles = Assessors::VehicleAssessor.call(@capital_summary.vehicles)
+      @vehicles = Assessors::VehicleAssessor.call(@capital_summary.vehicles, @submission_date)
     end
 
     attr_reader :pensioner_capital_disregard, :liquid_capital, :non_liquid_capital, :property, :vehicles

--- a/app/services/decorators/v5/assessment_decorator.rb
+++ b/app/services/decorators/v5/assessment_decorator.rb
@@ -9,8 +9,9 @@ module Decorators
                :remarks,
                :disposable_income_summary, to: :assessment
 
-      def initialize(assessment)
+      def initialize(assessment, calculation_output)
         @assessment = assessment
+        @calculation_output = calculation_output
       end
 
       def as_json
@@ -24,7 +25,7 @@ module Decorators
           version: assessment.version,
           timestamp: Time.current,
           success: true,
-          result_summary: ResultSummaryDecorator.new(assessment).as_json,
+          result_summary: ResultSummaryDecorator.new(assessment, @calculation_output).as_json,
           assessment: assessment_details,
         }
       end

--- a/app/services/decorators/v5/capital_result_decorator.rb
+++ b/app/services/decorators/v5/capital_result_decorator.rb
@@ -1,9 +1,9 @@
 module Decorators
   module V5
     class CapitalResultDecorator
-      def initialize(summary, person_capital_collation)
+      def initialize(summary, person_capital_subtotals)
         @summary = summary
-        @person_capital_collation = person_capital_collation
+        @person_capital_subtotals = person_capital_subtotals
       end
 
       def as_json
@@ -18,7 +18,7 @@ module Decorators
         {
           total_liquid: summary.total_liquid.to_f,
           total_non_liquid: summary.total_non_liquid.to_f,
-          total_vehicle: @person_capital_collation&.total_vehicle.to_f,
+          total_vehicle: @person_capital_subtotals&.total_vehicle.to_f,
           total_property: summary.total_property.to_f,
           total_mortgage_allowance: summary.total_mortgage_allowance.to_f,
           total_capital: summary.total_capital.to_f,

--- a/app/services/decorators/v5/capital_result_decorator.rb
+++ b/app/services/decorators/v5/capital_result_decorator.rb
@@ -18,7 +18,7 @@ module Decorators
         {
           total_liquid: summary.total_liquid.to_f,
           total_non_liquid: summary.total_non_liquid.to_f,
-          total_vehicle: @person_capital_subtotals&.total_vehicle.to_f,
+          total_vehicle: @person_capital_subtotals.total_vehicle.to_f,
           total_property: summary.total_property.to_f,
           total_mortgage_allowance: summary.total_mortgage_allowance.to_f,
           total_capital: summary.total_capital.to_f,

--- a/app/services/decorators/v5/capital_result_decorator.rb
+++ b/app/services/decorators/v5/capital_result_decorator.rb
@@ -1,8 +1,9 @@
 module Decorators
   module V5
     class CapitalResultDecorator
-      def initialize(summary)
+      def initialize(summary, person_capital_collation)
         @summary = summary
+        @person_capital_collation = person_capital_collation
       end
 
       def as_json
@@ -17,7 +18,7 @@ module Decorators
         {
           total_liquid: summary.total_liquid.to_f,
           total_non_liquid: summary.total_non_liquid.to_f,
-          total_vehicle: summary.total_vehicle.to_f,
+          total_vehicle: @person_capital_collation&.total_vehicle.to_f,
           total_property: summary.total_property.to_f,
           total_mortgage_allowance: summary.total_mortgage_allowance.to_f,
           total_capital: summary.total_capital.to_f,

--- a/app/services/decorators/v5/result_summary_decorator.rb
+++ b/app/services/decorators/v5/result_summary_decorator.rb
@@ -28,7 +28,7 @@ module Decorators
                                                                  partner_present: assessment.partner.present?).as_json,
           partner_disposable_income:,
           capital: CapitalResultDecorator.new(capital_summary,
-                                              @calculation_output&.capital_subtotals&.applicant_capital_subtotals).as_json,
+                                              @calculation_output.capital_subtotals.applicant_capital_subtotals).as_json,
           partner_capital:,
         }
       end
@@ -51,7 +51,7 @@ module Decorators
         return unless assessment.partner
 
         CapitalResultDecorator.new(assessment.partner_capital_summary,
-                                   @calculation_output&.capital_subtotals&.partner_capital_subtotals).as_json
+                                   @calculation_output.capital_subtotals&.partner_capital_subtotals).as_json
       end
     end
   end

--- a/app/services/decorators/v5/result_summary_decorator.rb
+++ b/app/services/decorators/v5/result_summary_decorator.rb
@@ -28,7 +28,7 @@ module Decorators
                                                                  partner_present: assessment.partner.present?).as_json,
           partner_disposable_income:,
           capital: CapitalResultDecorator.new(capital_summary,
-                                              @calculation_output&.capital_collation&.applicant_capital_collation).as_json,
+                                              @calculation_output&.capital_subtotals&.applicant_capital_subtotals).as_json,
           partner_capital:,
         }
       end
@@ -51,7 +51,7 @@ module Decorators
         return unless assessment.partner
 
         CapitalResultDecorator.new(assessment.partner_capital_summary,
-                                   @calculation_output&.capital_collation&.partner_capital_collation).as_json
+                                   @calculation_output&.capital_subtotals&.partner_capital_subtotals).as_json
       end
     end
   end

--- a/app/services/decorators/v5/result_summary_decorator.rb
+++ b/app/services/decorators/v5/result_summary_decorator.rb
@@ -8,8 +8,9 @@ module Decorators
                :gross_income_summary,
                to: :assessment
 
-      def initialize(assessment)
+      def initialize(assessment, calculation_output)
         @assessment = assessment
+        @calculation_output = calculation_output
       end
 
       def as_json
@@ -26,7 +27,8 @@ module Decorators
                                                                  gross_income_summary,
                                                                  partner_present: assessment.partner.present?).as_json,
           partner_disposable_income:,
-          capital: CapitalResultDecorator.new(capital_summary).as_json,
+          capital: CapitalResultDecorator.new(capital_summary,
+                                              @calculation_output&.capital_collation&.applicant_capital_collation).as_json,
           partner_capital:,
         }
       end
@@ -48,7 +50,8 @@ module Decorators
       def partner_capital
         return unless assessment.partner
 
-        CapitalResultDecorator.new(assessment.partner_capital_summary).as_json
+        CapitalResultDecorator.new(assessment.partner_capital_summary,
+                                   @calculation_output&.capital_collation&.partner_capital_collation).as_json
       end
     end
   end

--- a/app/services/workflows/main_workflow.rb
+++ b/app/services/workflows/main_workflow.rb
@@ -2,13 +2,14 @@ module Workflows
   class MainWorkflow < BaseWorkflowService
     def call
       version_5_verification(assessment)
-      if applicant_passported?
-        PassportedWorkflow.call(assessment)
-      else
-        NonPassportedWorkflow.call(assessment)
-      end
+      calculation_output = if applicant_passported?
+                             PassportedWorkflow.call(assessment)
+                           else
+                             NonPassportedWorkflow.call(assessment)
+                           end
       RemarkGenerators::Orchestrator.call(assessment)
       Assessors::MainAssessor.call(assessment)
+      calculation_output
     end
 
   private

--- a/app/services/workflows/non_passported_workflow.rb
+++ b/app/services/workflows/non_passported_workflow.rb
@@ -14,13 +14,13 @@ module Workflows
       return SelfEmployedWorkflow.call(assessment) if assessment.applicant.self_employed?
 
       collate_and_assess_gross_income
-      return CalculationOutput.new(capital_collation: nil) if assessment.gross_income_summary.ineligible?
+      return CalculationOutput.new(capital_subtotals: nil) if assessment.gross_income_summary.ineligible?
 
       disposable_income_assessment
-      return CalculationOutput.new(capital_collation: nil) if assessment.disposable_income_summary.ineligible?
+      return CalculationOutput.new(capital_subtotals: nil) if assessment.disposable_income_summary.ineligible?
 
-      capital_collation = collate_and_assess_capital
-      CalculationOutput.new(capital_collation:)
+      capital_subtotals = collate_and_assess_capital
+      CalculationOutput.new(capital_subtotals:)
     end
 
   private

--- a/app/services/workflows/non_passported_workflow.rb
+++ b/app/services/workflows/non_passported_workflow.rb
@@ -14,10 +14,10 @@ module Workflows
       return SelfEmployedWorkflow.call(assessment) if assessment.applicant.self_employed?
 
       collate_and_assess_gross_income
-      return CalculationOutput.new(capital_subtotals: nil) if assessment.gross_income_summary.ineligible?
+      return CalculationOutput.new if assessment.gross_income_summary.ineligible?
 
       disposable_income_assessment
-      return CalculationOutput.new(capital_subtotals: nil) if assessment.disposable_income_summary.ineligible?
+      return CalculationOutput.new if assessment.disposable_income_summary.ineligible?
 
       capital_subtotals = collate_and_assess_capital
       CalculationOutput.new(capital_subtotals:)

--- a/app/services/workflows/non_passported_workflow.rb
+++ b/app/services/workflows/non_passported_workflow.rb
@@ -14,12 +14,13 @@ module Workflows
       return SelfEmployedWorkflow.call(assessment) if assessment.applicant.self_employed?
 
       collate_and_assess_gross_income
-      return if assessment.gross_income_summary.ineligible?
+      return CalculationOutput.new(capital_collation: nil) if assessment.gross_income_summary.ineligible?
 
       disposable_income_assessment
-      return if assessment.disposable_income_summary.ineligible?
+      return CalculationOutput.new(capital_collation: nil) if assessment.disposable_income_summary.ineligible?
 
-      collate_and_assess_capital
+      capital_collation = collate_and_assess_capital
+      CalculationOutput.new(capital_collation:)
     end
 
   private

--- a/app/services/workflows/passported_workflow.rb
+++ b/app/services/workflows/passported_workflow.rb
@@ -2,8 +2,8 @@ module Workflows
   class PassportedWorkflow
     class << self
       def call(assessment)
-        capital_collation = CapitalCollatorAndAssessor.call assessment
-        CalculationOutput.new(capital_collation:)
+        capital_subtotals = CapitalCollatorAndAssessor.call assessment
+        CalculationOutput.new(capital_subtotals:)
       end
     end
   end

--- a/app/services/workflows/passported_workflow.rb
+++ b/app/services/workflows/passported_workflow.rb
@@ -2,7 +2,8 @@ module Workflows
   class PassportedWorkflow
     class << self
       def call(assessment)
-        CapitalCollatorAndAssessor.call assessment
+        capital_collation = CapitalCollatorAndAssessor.call assessment
+        CalculationOutput.new(capital_collation:)
       end
     end
   end

--- a/db/migrate/20230131154602_remove_total_vehicles_from_capital_summaries.rb
+++ b/db/migrate/20230131154602_remove_total_vehicles_from_capital_summaries.rb
@@ -1,0 +1,5 @@
+class RemoveTotalVehiclesFromCapitalSummaries < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :capital_summaries, :total_vehicle, :decimal, null: false, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_25_161914) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_31_154602) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -70,7 +70,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_25_161914) do
     t.uuid "assessment_id"
     t.decimal "total_liquid", default: "0.0", null: false
     t.decimal "total_non_liquid", default: "0.0", null: false
-    t.decimal "total_vehicle", default: "0.0", null: false
     t.decimal "total_property", default: "0.0", null: false
     t.decimal "total_mortgage_allowance", default: "0.0", null: false
     t.decimal "total_capital", default: "0.0", null: false

--- a/spec/requests/assessments_controller_spec.rb
+++ b/spec/requests/assessments_controller_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe AssessmentsController, type: :request do
         let(:decorator) { instance_double Decorators::V5::AssessmentDecorator }
 
         it "calls the required services and uses the V5 decorator" do
-          allow(Decorators::V5::AssessmentDecorator).to receive(:new).with(assessment).and_return(decorator)
+          allow(Decorators::V5::AssessmentDecorator).to receive(:new).with(assessment, nil).and_return(decorator)
           allow(decorator).to receive(:as_json).and_return("")
 
           get_assessment

--- a/spec/requests/assessments_controller_spec.rb
+++ b/spec/requests/assessments_controller_spec.rb
@@ -80,14 +80,14 @@ RSpec.describe AssessmentsController, type: :request do
   describe "GET /assessments/:id" do
     let(:option) { :below_lower_threshold }
     let(:now) { Time.zone.now }
+    let(:calculation_output) { CalculationOutput.new }
 
     subject(:get_assessment) { get assessment_path(assessment), headers: }
 
     context "calling the correct workflows assessors and decorators" do
       before do
         allow(Assessment).to receive(:find).with(assessment.id.to_s).and_return(assessment)
-        allow(Workflows::MainWorkflow).to receive(:call).with(assessment)
-        allow(Assessors::MainAssessor).to receive(:call).with(assessment)
+        allow(Workflows::MainWorkflow).to receive(:call).with(assessment).and_return(calculation_output)
       end
 
       let(:assessment) { create :assessment, :passported, :with_everything }
@@ -96,7 +96,8 @@ RSpec.describe AssessmentsController, type: :request do
         let(:decorator) { instance_double Decorators::V5::AssessmentDecorator }
 
         it "calls the required services and uses the V5 decorator" do
-          allow(Decorators::V5::AssessmentDecorator).to receive(:new).with(assessment, nil).and_return(decorator)
+          allow(Decorators::V5::AssessmentDecorator).to receive(:new).with(assessment, calculation_output)
+                                                                     .and_return(decorator)
           allow(decorator).to receive(:as_json).and_return("")
 
           get_assessment

--- a/spec/services/assessors/vehicle_assessor_spec.rb
+++ b/spec/services/assessors/vehicle_assessor_spec.rb
@@ -14,7 +14,7 @@ module Assessors
     end
 
     before do
-      described_class.call capital_summary.vehicles
+      described_class.call capital_summary.vehicles, assessment.submission_date
       vehicle.reload
     end
 

--- a/spec/services/creators/assessment_creator_spec.rb
+++ b/spec/services/creators/assessment_creator_spec.rb
@@ -76,7 +76,6 @@ module Creators
           it "creates all fields as zero" do
             expect(capital_summary.total_liquid).to eq 0.0
             expect(capital_summary.total_non_liquid).to eq 0.0
-            expect(capital_summary.total_vehicle).to eq 0.0
             expect(capital_summary.total_property).to eq 0.0
             expect(capital_summary.total_mortgage_allowance).to eq 0.0
             expect(capital_summary.pensioner_capital_disregard).to eq 0.0
@@ -142,7 +141,6 @@ module Creators
           it "creates all fields as zero" do
             expect(capital_summary.total_liquid).to eq 0.0
             expect(capital_summary.total_non_liquid).to eq 0.0
-            expect(capital_summary.total_vehicle).to eq 0.0
             expect(capital_summary.total_property).to eq 0.0
             expect(capital_summary.total_mortgage_allowance).to eq 0.0
             expect(capital_summary.pensioner_capital_disregard).to eq 0.0

--- a/spec/services/decorators/v5/assessment_decorator_spec.rb
+++ b/spec/services/decorators/v5/assessment_decorator_spec.rb
@@ -15,9 +15,9 @@ module Decorators
       end
       let(:calculation_output) do
         CalculationOutput.new(
-          capital_collation: CapitalCollatorAndAssessor::CapitalCollation.new(
-            CapitalCollatorAndAssessor::PersonCapitalCollation.new(0),
-            CapitalCollatorAndAssessor::PersonCapitalCollation.new(0),
+          capital_subtotals: CapitalCollatorAndAssessor::CapitalSubtotals.new(
+            applicant_capital_subtotals: CapitalCollatorAndAssessor::PersonCapitalSubtotals.new(total_vehicle: 0),
+            partner_capital_subtotals: CapitalCollatorAndAssessor::PersonCapitalSubtotals.new(total_vehicle: 0),
           ),
         )
       end

--- a/spec/services/decorators/v5/assessment_decorator_spec.rb
+++ b/spec/services/decorators/v5/assessment_decorator_spec.rb
@@ -15,9 +15,9 @@ module Decorators
       end
       let(:calculation_output) do
         CalculationOutput.new(
-          capital_subtotals: CapitalCollatorAndAssessor::CapitalSubtotals.new(
-            applicant_capital_subtotals: CapitalCollatorAndAssessor::PersonCapitalSubtotals.new(total_vehicle: 0),
-            partner_capital_subtotals: CapitalCollatorAndAssessor::PersonCapitalSubtotals.new(total_vehicle: 0),
+          capital_subtotals: CapitalSubtotals.new(
+            applicant_capital_subtotals: PersonCapitalSubtotals.new(total_vehicle: 0),
+            partner_capital_subtotals: PersonCapitalSubtotals.new(total_vehicle: 0),
           ),
         )
       end

--- a/spec/services/decorators/v5/assessment_decorator_spec.rb
+++ b/spec/services/decorators/v5/assessment_decorator_spec.rb
@@ -13,9 +13,17 @@ module Decorators
                :with_applicant,
                :with_eligibilities
       end
+      let(:calculation_output) do
+        CalculationOutput.new(
+          capital_collation: CapitalCollatorAndAssessor::CapitalCollation.new(
+            CapitalCollatorAndAssessor::PersonCapitalCollation.new(0),
+            CapitalCollatorAndAssessor::PersonCapitalCollation.new(0),
+          ),
+        )
+      end
 
       describe "#as_json" do
-        subject(:decorator) { described_class.new(assessment).as_json }
+        subject(:decorator) { described_class.new(assessment, calculation_output).as_json }
 
         it "has the required keys in the returned hash" do
           expected_keys = %i[

--- a/spec/services/decorators/v5/capital_result_decorator_spec.rb
+++ b/spec/services/decorators/v5/capital_result_decorator_spec.rb
@@ -26,7 +26,7 @@ module Decorators
                assessed_capital: 9_355,
                combined_assessed_capital: 12_000
       end
-      let(:subtotals) { CapitalCollatorAndAssessor::PersonCapitalSubtotals.new(total_vehicle: 3500) }
+      let(:subtotals) { PersonCapitalSubtotals.new(total_vehicle: 3500) }
 
       let(:expected_result) do
         {

--- a/spec/services/decorators/v5/capital_result_decorator_spec.rb
+++ b/spec/services/decorators/v5/capital_result_decorator_spec.rb
@@ -17,7 +17,6 @@ module Decorators
                assessment:,
                total_liquid: 9_355.23,
                total_non_liquid: 12_553.22,
-               total_vehicle: 3500,
                total_property: 835_500,
                total_mortgage_allowance: 750_000,
                total_capital: 24_000,
@@ -27,6 +26,7 @@ module Decorators
                assessed_capital: 9_355,
                combined_assessed_capital: 12_000
       end
+      let(:collation) { CapitalCollatorAndAssessor::PersonCapitalCollation.new(3500) }
 
       let(:expected_result) do
         {
@@ -73,7 +73,7 @@ module Decorators
         end
       end
 
-      subject(:decorator) { described_class.new(assessment.capital_summary).as_json }
+      subject(:decorator) { described_class.new(assessment.capital_summary, collation).as_json }
 
       describe "#as_json" do
         it "returns the expected structure" do

--- a/spec/services/decorators/v5/capital_result_decorator_spec.rb
+++ b/spec/services/decorators/v5/capital_result_decorator_spec.rb
@@ -26,7 +26,7 @@ module Decorators
                assessed_capital: 9_355,
                combined_assessed_capital: 12_000
       end
-      let(:collation) { CapitalCollatorAndAssessor::PersonCapitalCollation.new(3500) }
+      let(:subtotals) { CapitalCollatorAndAssessor::PersonCapitalSubtotals.new(total_vehicle: 3500) }
 
       let(:expected_result) do
         {
@@ -73,7 +73,7 @@ module Decorators
         end
       end
 
-      subject(:decorator) { described_class.new(assessment.capital_summary, collation).as_json }
+      subject(:decorator) { described_class.new(assessment.capital_summary, subtotals).as_json }
 
       describe "#as_json" do
         it "returns the expected structure" do

--- a/spec/services/workflows/passported_workflow_spec.rb
+++ b/spec/services/workflows/passported_workflow_spec.rb
@@ -20,8 +20,9 @@ module Workflows
       it "calls Capital collator and updates capital summary record" do
         allow(Collators::CapitalCollator).to receive(:call).and_return(capital_data)
         expect(Collators::CapitalCollator).to receive(:call)
-        workflow_call
-        expect(capital_summary.reload).to have_matching_attributes(capital_data)
+        result = workflow_call
+        expect(result.capital_collation.applicant_capital_collation.total_vehicle).to eq 500
+        expect(capital_summary.reload).to have_matching_attributes(capital_data.except(:total_vehicle))
       end
 
       it "calls CapitalAssessor and updates capital summary record with result" do

--- a/spec/services/workflows/passported_workflow_spec.rb
+++ b/spec/services/workflows/passported_workflow_spec.rb
@@ -21,7 +21,7 @@ module Workflows
         allow(Collators::CapitalCollator).to receive(:call).and_return(capital_data)
         expect(Collators::CapitalCollator).to receive(:call)
         result = workflow_call
-        expect(result.capital_collation.applicant_capital_collation.total_vehicle).to eq 500
+        expect(result.capital_subtotals.applicant_capital_subtotals.total_vehicle).to eq 500
         expect(capital_summary.reload).to have_matching_attributes(capital_data.except(:total_vehicle))
       end
 


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/EL-657)

As a first attempt to make CFE's eligibility calculation more functional, I've removed the "total_vehicle" column from the database, instead having its value be returned up the calculation method tree to the assessment controller, and passed into the decorator method tree.

I've not removed the vehicle assessed values from the database, but have moved the vehicle assessment method into VehicleAssessor and made a note of the database-y side effect. One day we'll be able to remove that too, but I think it's out of scope of this ticket.

For now I'm using structs to shape return values lower down the tree, and a CalculationOutput class to define the shape of the overall calculation output. But that's all very up for discussion.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
