### PR TITLE
Spike for non-persistence of assessed vehicle value

### DIFF
--- a/app/controllers/assessments_controller.rb
+++ b/app/controllers/assessments_controller.rb
@@ -29,8 +29,8 @@ private
   end
 
   def perform_assessment
-    Workflows::MainWorkflow.call(assessment)
-    render json: decorator_klass.new(assessment).as_json
+    result = Workflows::MainWorkflow.call(assessment)
+    render json: Decorators::V5::AssessmentDecorator.new(assessment, result).as_json
   end
 
   def version
@@ -47,9 +47,5 @@ private
 
   def assessment
     @assessment ||= Assessment.find(params[:id])
-  end
-
-  def decorator_klass
-    Decorators::V5::AssessmentDecorator
   end
 end

--- a/app/models/vehicle.rb
+++ b/app/models/vehicle.rb
@@ -1,45 +1,7 @@
 class Vehicle < ApplicationRecord
-  delegate :assessment, to: :capital_summary
-  delegate :submission_date, to: :assessment
-
   belongs_to :capital_summary
 
   validates :date_of_purchase, cfe_date: { not_in_the_future: true }
 
   scope :disputed, -> { where(subject_matter_of_dispute: true) }
-
-  def assess!
-    in_regular_use? ? assess_vehicle_in_regular_use : assess_vehicle_not_in_regular_use
-    save!
-  end
-
-private
-
-  def assess_vehicle_not_in_regular_use
-    self.included_in_assessment = true
-    self.assessed_value = value
-  end
-
-  def assess_vehicle_in_regular_use
-    net_value = value - loan_amount_outstanding
-    if vehicle_age_in_months >= vehicle_out_of_scope_age || net_value <= vehicle_disregard
-      self.included_in_assessment = false
-      self.assessed_value = 0
-    else
-      self.included_in_assessment = true
-      self.assessed_value = net_value - vehicle_disregard
-    end
-  end
-
-  def vehicle_age_in_months
-    Calculators::VehicleAgeCalculator.new(date_of_purchase, submission_date).in_months
-  end
-
-  def vehicle_out_of_scope_age
-    Threshold.value_for(:vehicle_out_of_scope_months, at: submission_date)
-  end
-
-  def vehicle_disregard
-    Threshold.value_for(:vehicle_disregard, at: submission_date)
-  end
 end

--- a/app/services/assessment_result.rb
+++ b/app/services/assessment_result.rb
@@ -1,0 +1,1 @@
+AssessmentResult = Struct.new :vehicles, :partner_vehicles, keyword_init: true

--- a/app/services/assessors/vehicle_assessor.rb
+++ b/app/services/assessors/vehicle_assessor.rb
@@ -1,9 +1,39 @@
 module Assessors
   class VehicleAssessor
     class << self
-      def call(vehicles)
-        vehicles.each(&:assess!)
-        vehicles.sum(&:assessed_value)
+      def call(value:, loan_amount_outstanding:, submission_date:, in_regular_use:, date_of_purchase:)
+        if in_regular_use
+          assess_vehicle_in_regular_use(value:, loan_amount_outstanding:, submission_date:, date_of_purchase:)
+        else
+          assess_vehicle_not_in_regular_use(value:)
+        end
+      end
+
+    private
+
+      def assess_vehicle_not_in_regular_use(value:)
+        VehicleResult.new(included_in_assessment: true, value:).freeze
+      end
+
+      def assess_vehicle_in_regular_use(value:, loan_amount_outstanding:, submission_date:, date_of_purchase:)
+        net_value = value - loan_amount_outstanding
+        if vehicle_age_in_months(date_of_purchase:, submission_date:) >= vehicle_out_of_scope_age(submission_date:) || net_value <= vehicle_disregard(submission_date:)
+          VehicleResult.new(included_in_assessment: false, value: 0).freeze
+        else
+          VehicleResult.new(included_in_assessment: true, value: net_value - vehicle_disregard(submission_date:)).freeze
+        end
+      end
+
+      def vehicle_age_in_months(date_of_purchase:, submission_date:)
+        Calculators::VehicleAgeCalculator.new(date_of_purchase, submission_date).in_months
+      end
+
+      def vehicle_out_of_scope_age(submission_date:)
+        Threshold.value_for(:vehicle_out_of_scope_months, at: submission_date)
+      end
+
+      def vehicle_disregard(submission_date:)
+        Threshold.value_for(:vehicle_disregard, at: submission_date)
       end
     end
   end

--- a/app/services/assessors/vehicle_result.rb
+++ b/app/services/assessors/vehicle_result.rb
@@ -1,0 +1,3 @@
+module Assessors
+  VehicleResult = Struct.new :included_in_assessment, :value, keyword_init: true
+end

--- a/app/services/calculators/subject_matter_of_dispute_disregard_calculator.rb
+++ b/app/services/calculators/subject_matter_of_dispute_disregard_calculator.rb
@@ -2,17 +2,19 @@
 # has already been calculated. If this is not the case, it will produce inaccurate results.
 module Calculators
   class SubjectMatterOfDisputeDisregardCalculator
-    delegate :disputed_capital_items, :disputed_vehicles, :disputed_properties, to: :@capital_summary
+    delegate :disputed_capital_items, :disputed_properties, to: :@capital_summary
 
-    def initialize(capital_summary:, maximum_disregard:)
+    def initialize(submission_date:, capital_summary:, maximum_disregard:, disputed_vehicle_value:)
+      @submission_date = submission_date
       @capital_summary = capital_summary
       @maximum_disregard = maximum_disregard
+      @disputed_vehicle_value = disputed_vehicle_value
     end
 
     def value
       total_disputed_asset_value = disputed_capital_value +
         disputed_property_value +
-        disputed_vehicle_value
+        @disputed_vehicle_value
 
       if total_disputed_asset_value.positive? && @maximum_disregard.nil?
         raise "SMOD assets listed but no threshold data found"
@@ -29,10 +31,6 @@ module Calculators
 
     def disputed_property_value
       disputed_properties.sum(:assessed_equity)
-    end
-
-    def disputed_vehicle_value
-      disputed_vehicles.sum(:assessed_value)
     end
   end
 end

--- a/app/services/capital_collator_and_assessor.rb
+++ b/app/services/capital_collator_and_assessor.rb
@@ -34,11 +34,11 @@ class CapitalCollatorAndAssessor
         assessment.capital_summary.update!(combined_assessed_capital: assessment.capital_summary.assessed_capital +
                                                                         assessment.partner_capital_summary.assessed_capital)
         Assessors::CapitalAssessor.call(assessment.capital_summary, assessment.capital_summary.combined_assessed_capital)
-        AssessmentResult.new vehicles: vehicles, partner_vehicles: partner_vehicles
+        AssessmentResult.new vehicles:, partner_vehicles:
       else
         assessment.capital_summary.update!(combined_assessed_capital: assessment.capital_summary.assessed_capital)
         Assessors::CapitalAssessor.call(assessment.capital_summary, assessment.capital_summary.combined_assessed_capital)
-        AssessmentResult.new vehicles: vehicles
+        AssessmentResult.new vehicles:
       end
     end
 

--- a/app/services/collators/capital_collator.rb
+++ b/app/services/collators/capital_collator.rb
@@ -2,8 +2,8 @@ module Collators
   class CapitalCollator
     RETURN_VALUES = {
       total_liquid: "liquid_capital",
-      total_non_liquid: "non_liquid_capital",
-      total_vehicle: "vehicles",
+      total_non_liquid: "total_non_liquid",
+      total_vehicle: "total_vehicle",
       total_mortgage_allowance: "property_maximum_mortgage_allowance_threshold",
       total_property: "property",
       pensioner_capital_disregard: "pensioner_capital_disregard",
@@ -26,36 +26,58 @@ module Collators
     end
 
     def call
-      perform_assessments
-      RETURN_VALUES.deep_transform_values { |value| send(value) }
+      RETURN_VALUES.transform_values { |value| send(value) }
     end
 
   private
 
-    def perform_assessments
-      @liquid_capital = Assessors::LiquidCapitalAssessor.call(@capital_summary)
-      @non_liquid_capital = Assessors::NonLiquidCapitalAssessor.call(@capital_summary)
-      @property = Calculators::PropertyCalculator.call(submission_date: @submission_date, capital_summary: @capital_summary)
-      @vehicles = Assessors::VehicleAssessor.call(@capital_summary.vehicles)
+    def property
+      @property ||= Calculators::PropertyCalculator.call(submission_date: @submission_date, capital_summary: @capital_summary)
     end
 
-    attr_reader :pensioner_capital_disregard, :liquid_capital, :non_liquid_capital, :property, :vehicles
+    def liquid_capital
+      @liquid_capital ||= Assessors::LiquidCapitalAssessor.call(@capital_summary)
+    end
+
+    def total_non_liquid
+      @total_non_liquid ||= Assessors::NonLiquidCapitalAssessor.call(@capital_summary)
+    end
+
+    def total_vehicle
+      @total_vehicle ||= vehicle_value(@capital_summary.vehicles)
+    end
+
+    attr_reader :pensioner_capital_disregard
 
     def assessed_capital
       total_capital - pensioner_capital_disregard - subject_matter_of_dispute_disregard
     end
 
     def subject_matter_of_dispute_disregard
-      Calculators::SubjectMatterOfDisputeDisregardCalculator.new(capital_summary: @capital_summary,
-                                                                 maximum_disregard: @maximum_subject_matter_of_dispute_disregard).value
+      Calculators::SubjectMatterOfDisputeDisregardCalculator.new(
+        disputed_vehicle_value: vehicle_value(@capital_summary.disputed_vehicles),
+        submission_date: @submission_date,
+        capital_summary: @capital_summary,
+        maximum_disregard: @maximum_subject_matter_of_dispute_disregard,
+      ).value
     end
 
     def total_capital
-      @total_capital ||= liquid_capital + non_liquid_capital + vehicles + property
+      @total_capital ||= liquid_capital + total_non_liquid + total_vehicle + property
     end
 
     def property_maximum_mortgage_allowance_threshold
       Threshold.value_for(:property_maximum_mortgage_allowance, at: @submission_date)
+    end
+
+    def vehicle_value(vehicles)
+      vehicles.sum do |v|
+        Assessors::VehicleAssessor.call(value: v.value,
+                                        loan_amount_outstanding: v.loan_amount_outstanding,
+                                        submission_date: @submission_date,
+                                        in_regular_use: v.in_regular_use,
+                                        date_of_purchase: v.date_of_purchase).value
+      end
     end
   end
 end

--- a/app/services/decorators/v5/assessment_decorator.rb
+++ b/app/services/decorators/v5/assessment_decorator.rb
@@ -1,16 +1,14 @@
 module Decorators
   module V5
     class AssessmentDecorator
-      attr_reader :assessment
-
       delegate :applicant,
-               :capital_summary,
                :gross_income_summary,
                :remarks,
                :disposable_income_summary, to: :assessment
 
-      def initialize(assessment)
+      def initialize(assessment, result)
         @assessment = assessment
+        @result = result
       end
 
       def as_json
@@ -18,6 +16,8 @@ module Decorators
       end
 
     private
+
+      attr_reader :assessment
 
       def payload
         {
@@ -39,7 +39,7 @@ module Decorators
           partner_gross_income:,
           disposable_income: DisposableIncomeDecorator.new(disposable_income_summary).as_json,
           partner_disposable_income:,
-          capital: CapitalDecorator.new(capital_summary).as_json,
+          capital: CapitalDecorator.new(assessment.capital_summary, @result.vehicles).as_json,
           partner_capital:,
           remarks: RemarksDecorator.new(remarks, assessment).as_json,
         }
@@ -61,7 +61,7 @@ module Decorators
       def partner_capital
         return unless assessment.partner
 
-        CapitalDecorator.new(assessment.partner_capital_summary).as_json
+        CapitalDecorator.new(assessment.partner_capital_summary, @result.partner_vehicles).as_json
       end
     end
   end

--- a/app/services/decorators/v5/capital_decorator.rb
+++ b/app/services/decorators/v5/capital_decorator.rb
@@ -1,8 +1,9 @@
 module Decorators
   module V5
     class CapitalDecorator
-      def initialize(summary)
+      def initialize(summary, result)
         @summary = summary
+        @result = result
       end
 
       def as_json
@@ -46,7 +47,16 @@ module Decorators
       end
 
       def vehicles
-        @summary.vehicles.map { |v| VehicleDecorator.new(v).as_json }
+        @summary.vehicles.map do |v|
+          value = Assessors::VehicleAssessor.call(
+            value: v.value,
+            loan_amount_outstanding: v.loan_amount_outstanding,
+            date_of_purchase: v.date_of_purchase,
+            in_regular_use: v.in_regular_use,
+            submission_date: @summary.assessment.submission_date,
+          )
+          VehicleDecorator.new(v, value).as_json
+        end
       end
     end
   end

--- a/app/services/decorators/v5/vehicle_decorator.rb
+++ b/app/services/decorators/v5/vehicle_decorator.rb
@@ -1,8 +1,9 @@
 module Decorators
   module V5
     class VehicleDecorator
-      def initialize(record)
+      def initialize(record, result)
         @record = record
+        @result = result
       end
 
       def as_json
@@ -11,10 +12,16 @@ module Decorators
           loan_amount_outstanding: @record.loan_amount_outstanding.to_f,
           date_of_purchase: @record.date_of_purchase,
           in_regular_use: @record.in_regular_use,
-          included_in_assessment: @record.included_in_assessment,
-          disregards_and_deductions: @record.value.to_f - @record.assessed_value.to_f - @record.loan_amount_outstanding.to_f,
-          assessed_value: @record.assessed_value.to_f,
+          included_in_assessment: @result.included_in_assessment,
+          disregards_and_deductions: @record.value.to_f - assessed_value - @record.loan_amount_outstanding.to_f,
+          assessed_value:,
         }
+      end
+
+    private
+
+      def assessed_value
+        @result.value.to_f
       end
     end
   end

--- a/app/services/workflows/main_workflow.rb
+++ b/app/services/workflows/main_workflow.rb
@@ -1,25 +1,28 @@
 module Workflows
-  class MainWorkflow < BaseWorkflowService
-    def call
-      version_5_verification(assessment)
-      if applicant_passported?
-        PassportedWorkflow.call(assessment)
-      else
-        NonPassportedWorkflow.call(assessment)
+  class MainWorkflow
+    class << self
+      def call(assessment)
+        version_5_verification(assessment)
+        result = if applicant_passported? assessment
+                   PassportedWorkflow.call(assessment)
+                 else
+                   NonPassportedWorkflow.call(assessment)
+                 end
+        RemarkGenerators::Orchestrator.call(assessment)
+        Assessors::MainAssessor.call(assessment)
+        result
       end
-      RemarkGenerators::Orchestrator.call(assessment)
-      Assessors::MainAssessor.call(assessment)
-    end
 
-  private
+    private
 
-    def applicant_passported?
-      applicant.receives_qualifying_benefit?
-    end
+      def applicant_passported?(assessment)
+        assessment.applicant.receives_qualifying_benefit?
+      end
 
-    def version_5_verification(assessment)
-      Utilities::ProceedingTypeThresholdPopulator.call(assessment)
-      Creators::EligibilitiesCreator.call(assessment)
+      def version_5_verification(assessment)
+        Utilities::ProceedingTypeThresholdPopulator.call(assessment)
+        Creators::EligibilitiesCreator.call(assessment)
+      end
     end
   end
 end

--- a/app/services/workflows/non_passported_workflow.rb
+++ b/app/services/workflows/non_passported_workflow.rb
@@ -14,10 +14,10 @@ module Workflows
       return SelfEmployedWorkflow.call(assessment) if assessment.applicant.self_employed?
 
       collate_and_assess_gross_income
-      return if assessment.gross_income_summary.ineligible?
+      return AssessmentResult.new if assessment.gross_income_summary.ineligible?
 
       disposable_income_assessment
-      return if assessment.disposable_income_summary.ineligible?
+      return AssessmentResult.new if assessment.disposable_income_summary.ineligible?
 
       collate_and_assess_capital
     end

--- a/db/migrate/20230131155418_remove_vehicle_value_from_database.rb
+++ b/db/migrate/20230131155418_remove_vehicle_value_from_database.rb
@@ -1,0 +1,14 @@
+class RemoveVehicleValueFromDatabase < ActiveRecord::Migration[7.0]
+  def up
+    change_table :vehicles, bulk: true do |t|
+      t.remove :assessed_value, :included_in_assessment
+    end
+  end
+
+  def down
+    change_table :vehicles, bulk: true do |t|
+      t.boolean :included_in_assessment, default: false, null: false
+      t.decimal :assessed_value
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_25_161914) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_31_155418) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -394,8 +394,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_25_161914) do
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
     t.uuid "capital_summary_id"
-    t.boolean "included_in_assessment", default: false, null: false
-    t.decimal "assessed_value"
     t.boolean "subject_matter_of_dispute"
     t.index ["capital_summary_id"], name: "index_vehicles_on_capital_summary_id"
   end

--- a/spec/requests/assessments_controller_spec.rb
+++ b/spec/requests/assessments_controller_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe AssessmentsController, type: :request do
         let(:decorator) { instance_double Decorators::V5::AssessmentDecorator }
 
         it "calls the required services and uses the V5 decorator" do
-          allow(Decorators::V5::AssessmentDecorator).to receive(:new).with(assessment).and_return(decorator)
+          allow(Decorators::V5::AssessmentDecorator).to receive(:new).and_return(decorator)
           allow(decorator).to receive(:as_json).and_return("")
 
           get_assessment

--- a/spec/services/assessors/vehicle_assessor_spec.rb
+++ b/spec/services/assessors/vehicle_assessor_spec.rb
@@ -4,7 +4,7 @@ module Assessors
   RSpec.describe VehicleAssessor do
     let(:assessment) { create :assessment, :with_capital_summary }
     let(:capital_summary) { assessment.capital_summary }
-    let!(:vehicle) do
+    let(:vehicle) do
       create :vehicle,
              capital_summary:,
              value: estimated_value,
@@ -13,9 +13,11 @@ module Assessors
              in_regular_use:
     end
 
-    before do
-      described_class.call capital_summary.vehicles
-      vehicle.reload
+    let(:result) do
+      described_class.call value: vehicle.value, in_regular_use: vehicle.in_regular_use,
+                           loan_amount_outstanding: vehicle.loan_amount_outstanding,
+                           submission_date: assessment.submission_date,
+                           date_of_purchase: vehicle.date_of_purchase
     end
 
     describe "#call" do
@@ -30,8 +32,7 @@ module Assessors
             let(:loan_amount_outstanding) { 0.0 }
 
             it "is not included in the assessment" do
-              expect(vehicle.included_in_assessment).to be false
-              expect(vehicle.assessed_value).to eq 0.0
+              expect(result).to eq(VehicleResult.new(included_in_assessment: false, value: 0))
             end
           end
 
@@ -40,8 +41,7 @@ module Assessors
             let(:loan_amount_outstanding) { 0.0 }
 
             it "is not included in the assessment" do
-              expect(vehicle.included_in_assessment).to be false
-              expect(vehicle.assessed_value).to eq 0.0
+              expect(result).to eq(VehicleResult.new(included_in_assessment: false, value: 0))
             end
           end
         end
@@ -56,8 +56,7 @@ module Assessors
               let(:date_of_purchase) { 37.months.ago.to_date }
 
               it "is not included in the assessment" do
-                expect(vehicle.included_in_assessment).to be false
-                expect(vehicle.assessed_value).to eq 0.0
+                expect(result).to eq(VehicleResult.new(included_in_assessment: false, value: 0))
               end
             end
 
@@ -65,8 +64,7 @@ module Assessors
               let(:date_of_purchase) { 3.months.ago.to_date }
 
               it "is not included in the assessment" do
-                expect(vehicle.included_in_assessment).to be false
-                expect(vehicle.assessed_value).to eq 0.0
+                expect(result).to eq(VehicleResult.new(included_in_assessment: false, value: 0))
               end
             end
           end
@@ -78,8 +76,7 @@ module Assessors
               let(:date_of_purchase) { 40.months.ago.to_date }
 
               it "is not included in the assessment" do
-                expect(vehicle.included_in_assessment).to be false
-                expect(vehicle.assessed_value).to eq 0.0
+                expect(result).to eq(VehicleResult.new(included_in_assessment: false, value: 0))
               end
             end
 
@@ -87,8 +84,7 @@ module Assessors
               let(:date_of_purchase) { 10.months.ago.to_date }
 
               it "is assessed at estimated value - loan amount outstanding - 15,000" do
-                expect(vehicle.included_in_assessment).to be true
-                expect(vehicle.assessed_value).to eq 4_000.0
+                expect(result).to eq(VehicleResult.new(included_in_assessment: true, value: 4000.0))
               end
             end
           end
@@ -106,8 +102,7 @@ module Assessors
             let(:loan_amount_outstanding) { 1_000.0 }
 
             it "is assessed at the estimated value" do
-              expect(vehicle.included_in_assessment).to be true
-              expect(vehicle.assessed_value).to eq 18_450.0
+              expect(result).to eq(VehicleResult.new(included_in_assessment: true, value: 18_450.0))
             end
           end
 
@@ -115,8 +110,7 @@ module Assessors
             let(:loan_amount_outstanding) { 12_000 }
 
             it "is assessed at the estimated value" do
-              expect(vehicle.included_in_assessment).to be true
-              expect(vehicle.assessed_value).to eq 18_450.0
+              expect(result).to eq(VehicleResult.new(included_in_assessment: true, value: 18_450.0))
             end
           end
         end
@@ -128,8 +122,7 @@ module Assessors
             let(:loan_amount_outstanding) { 0.0 }
 
             it "is assessed at the estimated value" do
-              expect(vehicle.included_in_assessment).to be true
-              expect(vehicle.assessed_value).to eq 18_450.0
+              expect(result).to eq(VehicleResult.new(included_in_assessment: true, value: 18_450.0))
             end
           end
 
@@ -137,8 +130,7 @@ module Assessors
             let(:loan_amount_outstanding) { 10_900.0 }
 
             it "is assessed at the estimated value" do
-              expect(vehicle.included_in_assessment).to be true
-              expect(vehicle.assessed_value).to eq 18_450.0
+              expect(result).to eq(VehicleResult.new(included_in_assessment: true, value: 18_450.0))
             end
           end
         end

--- a/spec/services/collators/capital_collator_spec.rb
+++ b/spec/services/collators/capital_collator_spec.rb
@@ -40,8 +40,12 @@ module Collators
       end
 
       context "vehicle assessment" do
+        before do
+          create(:vehicle, capital_summary: assessment.capital_summary)
+        end
+
         it "instantiates and calls the Vehicle Assesment service" do
-          allow(Assessors::VehicleAssessor).to receive(:call).and_return(2_500.0)
+          allow(Assessors::VehicleAssessor).to receive(:call).and_return(Assessors::VehicleResult.new(value: 2_500.0))
           collator
           expect(collator[:total_vehicle]).to eq 2_500.0
         end
@@ -56,6 +60,10 @@ module Collators
       end
 
       context "summarization of result_fields" do
+        before do
+          create(:vehicle, capital_summary: assessment.capital_summary)
+        end
+
         let(:pcd_value) { 100_000 }
 
         it "summarizes the results it gets from the subservices" do
@@ -65,7 +73,7 @@ module Collators
 
           allow(Assessors::LiquidCapitalAssessor).to receive(:call).and_return(145.83)
           allow(Assessors::NonLiquidCapitalAssessor).to receive(:call).and_return(500)
-          allow(Assessors::VehicleAssessor).to receive(:call).and_return(2_500.0)
+          allow(Assessors::VehicleAssessor).to receive(:call).and_return(Assessors::VehicleResult.new(value: 2_500.0))
           allow(property_service).to receive(:call).and_return(23_000.0)
 
           collator

--- a/spec/services/decorators/v5/assessment_decorator_spec.rb
+++ b/spec/services/decorators/v5/assessment_decorator_spec.rb
@@ -15,7 +15,7 @@ module Decorators
       end
 
       describe "#as_json" do
-        subject(:decorator) { described_class.new(assessment).as_json }
+        subject(:decorator) { described_class.new(assessment, AssessmentResult.new).as_json }
 
         it "has the required keys in the returned hash" do
           expected_keys = %i[

--- a/spec/services/decorators/v5/vehicle_decorator_spec.rb
+++ b/spec/services/decorators/v5/vehicle_decorator_spec.rb
@@ -7,11 +7,13 @@ RSpec.describe Decorators::V5::VehicleDecorator do
            value: 12_000.0,
            loan_amount_outstanding: 1250.44,
            date_of_purchase: purchase_date,
-           in_regular_use: false,
-           assessed_value: 0
+           in_regular_use: false
+  end
+  let(:result) do
+    Assessors::VehicleResult.new(value: 0, included_in_assessment: false)
   end
 
-  subject(:decorator) { described_class.new(vehicle) }
+  subject(:decorator) { described_class.new(vehicle, result) }
 
   describe "#as_json" do
     it "returns hash in correct format" do

--- a/spec/services/workflows/non_passported_workflow_spec.rb
+++ b/spec/services/workflows/non_passported_workflow_spec.rb
@@ -75,6 +75,7 @@ module Workflows
 
           before do
             create(:partner, :over_pensionable_age, assessment:)
+            create(:vehicle, capital_summary: assessment.partner_capital_summary, value: 0)
             create(:property, :additional_property, capital_summary: assessment.partner_capital_summary,
                                                     value: 170_000, outstanding_mortgage: 100_000, percentage_owned: 100)
           end


### PR DESCRIPTION
This is a spike to the concept of removing the 2 calculated values from the vehicles table, as a pre-cursor to https://dsdmoj.atlassian.net/browse/EL-657

This is deliberately somewhat untidy - tidying it up would effectively be doing EL-657, as the main issue is the awkward calculation of vehicle data (and then discarding it) in CapitalCollator