### PR TITLE
Update system gems with sudo - otherwise it fails with permission denied

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,7 +108,7 @@ references:
     run:
       name: Install ruby gems
       command: |
-        gem update --system
+        sudo gem update --system
         bundle install --without development --path=vendor/bundle --jobs=4 && bundle clean
   save_gems_cache: &save_gems_cache
     save_cache:


### PR DESCRIPTION
Change the circle-ci config to correctly call sudo gem update --system so that it doesn't fail with permission denied