### PR TITLE
Cache apt-get to help resolve build slowness

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 executors:
   basic-executor:
     docker:
-      - image: cimg/base:2020.01
+      - image: cimg/base:2022
   cloud-platform-executor:
     docker:
       - image: ministryofjustice/cloud-platform-tools:2.1
@@ -83,14 +83,11 @@ references:
     run:
       name: Update packages
       command: sudo apt-get update
-  upgrade_packages: &upgrade_packages
-    run:
-      name: Update packages
-      command: sudo apt-get -y upgrade
   install_packages_for_testing: &install_packages_for_testing
     run:
       name: Install System packages needed for testing
       command: |
+        sudo apt-get update
         sudo apt-get install -y postgresql-client
   install_git_crypt: &install_git_crypt
     run:
@@ -200,17 +197,10 @@ jobs:
       - setup_remote_docker:
           version: 20.10.7
       - *update_packages
-      - restore_cache:
-          key: cfep-apt-get-v1-{{ checksum "/var/cache/apt/pkgcache.bin" }}
-      - *upgrade_packages
       - *install_git_crypt
       - *decrypt_secrets
       - *build_docker_image
       - *setup_aws_login
-      - save_cache:
-          key: cfep-apt-get-v1-{{ checksum "/var/cache/apt/pkgcache.bin" }}
-          paths:
-            - /var/cache/apt/archives
       - *push_to_ecr
 
   deploy_uat: &deploy_uat

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,11 +83,14 @@ references:
     run:
       name: Update packages
       command: sudo apt-get update
+  upgrade_packages: &upgrade_packages
+    run:
+      name: Update packages
+      command: sudo apt-get upgrade
   install_packages_for_testing: &install_packages_for_testing
     run:
       name: Install System packages needed for testing
       command: |
-        sudo apt-get update
         sudo apt-get install -y postgresql-client
   install_git_crypt: &install_git_crypt
     run:
@@ -197,10 +200,17 @@ jobs:
       - setup_remote_docker:
           version: 20.10.7
       - *update_packages
+      - restore_cache:
+          key: cfep-apt-get-v1-{{ checksum "/var/cache/apt/pkgcache.bin" }}
+      - *upgrade_packages
       - *install_git_crypt
       - *decrypt_secrets
       - *build_docker_image
       - *setup_aws_login
+      - save_cache:
+          key: cfep-apt-get-v1-{{ checksum "/var/cache/apt/pkgcache.bin" }}
+          paths:
+            - /var/cache/apt/archives
       - *push_to_ecr
 
   deploy_uat: &deploy_uat

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 executors:
   basic-executor:
     docker:
-      - image: cimg/deploy:2020.01
+      - image: cimg/deploy:2023.01.1
   cloud-platform-executor:
     docker:
       - image: ministryofjustice/cloud-platform-tools:2.1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 executors:
   basic-executor:
     docker:
-      - image: cimg/base:2022
+      - image: cimg/base:2022.01
   cloud-platform-executor:
     docker:
       - image: ministryofjustice/cloud-platform-tools:2.1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,7 +86,7 @@ references:
   upgrade_packages: &upgrade_packages
     run:
       name: Update packages
-      command: sudo apt-get upgrade
+      command: sudo apt-get -y upgrade
   install_packages_for_testing: &install_packages_for_testing
     run:
       name: Install System packages needed for testing

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 executors:
   basic-executor:
     docker:
-      - image: cimg/base:2022.01
+      - image: cimg/aws:2020.01
   cloud-platform-executor:
     docker:
       - image: ministryofjustice/cloud-platform-tools:2.1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 executors:
   basic-executor:
     docker:
-      - image: cimg/aws:2020.01
+      - image: cimg/deploy:2020.01
   cloud-platform-executor:
     docker:
       - image: ministryofjustice/cloud-platform-tools:2.1


### PR DESCRIPTION
Most builds are dependant on the speed of apt-get - which can of course be cached locally between runs