### PR TITLE
EL-658: Remove attributes from capital summary

### DIFF
--- a/app/lib/calculation_output.rb
+++ b/app/lib/calculation_output.rb
@@ -1,7 +1,15 @@
 class CalculationOutput
-  def initialize(capital_subtotals: CapitalSubtotals.new)
-    @capital_subtotals = capital_subtotals
+  def initialize(capital_subtotals: nil)
+    @capital_subtotals = capital_subtotals || instantiate_blank_capital_subtotals
   end
 
   attr_reader :capital_subtotals
+
+private
+
+  def instantiate_blank_capital_subtotals
+    CapitalSubtotals.new(
+      applicant_capital_subtotals: PersonCapitalSubtotals.new,
+    )
+  end
 end

--- a/app/lib/capital_subtotals.rb
+++ b/app/lib/capital_subtotals.rb
@@ -1,5 +1,5 @@
 class CapitalSubtotals
-  def initialize(applicant_capital_subtotals: PersonCapitalSubtotals.new, partner_capital_subtotals: PersonCapitalSubtotals.new, capital_contribution: nil, combined_assessed_capital: nil)
+  def initialize(applicant_capital_subtotals:, partner_capital_subtotals: nil, capital_contribution: nil, combined_assessed_capital: nil)
     @applicant_capital_subtotals = applicant_capital_subtotals
     @partner_capital_subtotals = partner_capital_subtotals
     @capital_contribution = capital_contribution

--- a/app/lib/capital_subtotals.rb
+++ b/app/lib/capital_subtotals.rb
@@ -1,9 +1,10 @@
 class CapitalSubtotals
-  def initialize(applicant_capital_subtotals: PersonCapitalSubtotals.new, partner_capital_subtotals: PersonCapitalSubtotals.new, capital_contribution: nil)
+  def initialize(applicant_capital_subtotals: PersonCapitalSubtotals.new, partner_capital_subtotals: PersonCapitalSubtotals.new, capital_contribution: nil, combined_assessed_capital: nil)
     @applicant_capital_subtotals = applicant_capital_subtotals
     @partner_capital_subtotals = partner_capital_subtotals
     @capital_contribution = capital_contribution
+    @combined_assessed_capital = combined_assessed_capital
   end
 
-  attr_reader :applicant_capital_subtotals, :partner_capital_subtotals, :capital_contribution
+  attr_reader :applicant_capital_subtotals, :partner_capital_subtotals, :capital_contribution, :combined_assessed_capital
 end

--- a/app/lib/capital_subtotals.rb
+++ b/app/lib/capital_subtotals.rb
@@ -1,8 +1,9 @@
 class CapitalSubtotals
-  def initialize(applicant_capital_subtotals: PersonCapitalSubtotals.new, partner_capital_subtotals: PersonCapitalSubtotals.new)
+  def initialize(applicant_capital_subtotals: PersonCapitalSubtotals.new, partner_capital_subtotals: PersonCapitalSubtotals.new, capital_contribution: nil)
     @applicant_capital_subtotals = applicant_capital_subtotals
     @partner_capital_subtotals = partner_capital_subtotals
+    @capital_contribution = capital_contribution
   end
 
-  attr_reader :applicant_capital_subtotals, :partner_capital_subtotals
+  attr_reader :applicant_capital_subtotals, :partner_capital_subtotals, :capital_contribution
 end

--- a/app/lib/person_capital_subtotals.rb
+++ b/app/lib/person_capital_subtotals.rb
@@ -3,21 +3,23 @@ class PersonCapitalSubtotals
     @total_vehicle = data[:total_vehicle]
     @assessed_capital = data[:assessed_capital]
     @assessment_result = data[:assessment_result]
-    @capital_contribution = data[:capital_contribution]
     @total_capital = data[:total_capital]
     @total_liquid = data[:total_liquid]
     @total_mortgage_allowance = data[:total_mortgage_allowance]
     @total_non_liquid = data[:total_non_liquid]
     @total_property = data[:total_property]
+    @subject_matter_of_dispute_disregard = data[:subject_matter_of_dispute_disregard]
+    @pensioner_capital_disregard = data[:pensioner_capital_disregard]
   end
 
   attr_reader :total_vehicle,
               :assessed_capital,
               :assessment_result,
-              :capital_contribution,
               :total_capital,
               :total_liquid,
               :total_mortgage_allowance,
               :total_non_liquid,
-              :total_property
+              :total_property,
+              :subject_matter_of_dispute_disregard,
+              :pensioner_capital_disregard
 end

--- a/app/lib/person_capital_subtotals.rb
+++ b/app/lib/person_capital_subtotals.rb
@@ -1,7 +1,23 @@
 class PersonCapitalSubtotals
-  def initialize(total_vehicle: nil)
-    @total_vehicle = total_vehicle
+  def initialize(data = {})
+    @total_vehicle = data[:total_vehicle]
+    @assessed_capital = data[:assessed_capital]
+    @assessment_result = data[:assessment_result]
+    @capital_contribution = data[:capital_contribution]
+    @total_capital = data[:total_capital]
+    @total_liquid = data[:total_liquid]
+    @total_mortgage_allowance = data[:total_mortgage_allowance]
+    @total_non_liquid = data[:total_non_liquid]
+    @total_property = data[:total_property]
   end
 
-  attr_reader :total_vehicle
+  attr_reader :total_vehicle,
+              :assessed_capital,
+              :assessment_result,
+              :capital_contribution,
+              :total_capital,
+              :total_liquid,
+              :total_mortgage_allowance,
+              :total_non_liquid,
+              :total_property
 end

--- a/app/services/assessors/capital_assessor.rb
+++ b/app/services/assessors/capital_assessor.rb
@@ -3,19 +3,8 @@ module Assessors
     class << self
       def call(capital_summary, assessed_capital)
         capital_summary.eligibilities.each { |elig| elig.update_assessment_result! assessed_capital }
-        set_capital_contribution(capital_summary, assessed_capital)
-        summary_result(capital_summary)
-      end
-
-    private
-
-      def summary_result(capital_summary)
-        Utilities::ResultSummarizer.call(capital_summary.eligibilities.map(&:assessment_result))
-      end
-
-      def set_capital_contribution(capital_summary, assessed_capital)
         threshold = capital_summary.eligibilities.map(&:lower_threshold).min
-        capital_summary.update!(capital_contribution: [0, assessed_capital - threshold].max)
+        [0, assessed_capital - threshold].max
       end
     end
   end

--- a/app/services/capital_collator_and_assessor.rb
+++ b/app/services/capital_collator_and_assessor.rb
@@ -1,17 +1,17 @@
 class CapitalCollatorAndAssessor
   class << self
     def call(assessment)
-      data = collate_applicant_capital(assessment)
+      applicant_subtotals = collate_applicant_capital(assessment)
       if assessment.partner.present?
-        partner_data = collate_partner_capital(assessment)
-        combined_assessed_capital = data[:assessed_capital] + partner_data[:assessed_capital]
+        partner_subtotals = collate_partner_capital(assessment)
+        combined_assessed_capital = applicant_subtotals.assessed_capital + partner_subtotals.assessed_capital
       else
-        combined_assessed_capital = data[:assessed_capital]
+        combined_assessed_capital = applicant_subtotals.assessed_capital
       end
       capital_contribution = Assessors::CapitalAssessor.call(assessment.capital_summary, combined_assessed_capital)
       CapitalSubtotals.new(
-        applicant_capital_subtotals: PersonCapitalSubtotals.new(data),
-        partner_capital_subtotals: (PersonCapitalSubtotals.new(partner_data) if assessment.partner.present?),
+        applicant_capital_subtotals: applicant_subtotals,
+        partner_capital_subtotals: partner_subtotals,
         capital_contribution:,
         combined_assessed_capital:,
       )

--- a/app/services/capital_collator_and_assessor.rb
+++ b/app/services/capital_collator_and_assessor.rb
@@ -2,18 +2,18 @@ class CapitalCollatorAndAssessor
   class << self
     def call(assessment)
       data = collate_applicant_capital(assessment)
-      assessment.capital_summary.update!(data.slice(:subject_matter_of_dispute_disregard, :pensioner_capital_disregard))
       if assessment.partner.present?
         partner_data = collate_partner_capital(assessment)
-        assessment.capital_summary.update!(combined_assessed_capital: data[:assessed_capital] + partner_data[:assessed_capital])
+        combined_assessed_capital = data[:assessed_capital] + partner_data[:assessed_capital]
       else
-        assessment.capital_summary.update!(combined_assessed_capital: data[:assessed_capital])
+        combined_assessed_capital = data[:assessed_capital]
       end
-      contribution = Assessors::CapitalAssessor.call(assessment.capital_summary, assessment.capital_summary.combined_assessed_capital)
+      capital_contribution = Assessors::CapitalAssessor.call(assessment.capital_summary, combined_assessed_capital)
       CapitalSubtotals.new(
         applicant_capital_subtotals: PersonCapitalSubtotals.new(data),
         partner_capital_subtotals: (PersonCapitalSubtotals.new(partner_data) if assessment.partner.present?),
-        capital_contribution: contribution,
+        capital_contribution:,
+        combined_assessed_capital:,
       )
     end
 

--- a/app/services/capital_collator_and_assessor.rb
+++ b/app/services/capital_collator_and_assessor.rb
@@ -2,19 +2,18 @@ class CapitalCollatorAndAssessor
   class << self
     def call(assessment)
       data = collate_applicant_capital(assessment)
-      assessment.capital_summary.update!(data.except(:total_vehicle))
+      assessment.capital_summary.update!(data.slice(:subject_matter_of_dispute_disregard, :pensioner_capital_disregard))
       if assessment.partner.present?
         partner_data = collate_partner_capital(assessment)
-        assessment.partner_capital_summary.update!(partner_data.except(:total_vehicle))
-        assessment.capital_summary.update!(combined_assessed_capital: assessment.capital_summary.assessed_capital +
-                                                                        assessment.partner_capital_summary.assessed_capital)
+        assessment.capital_summary.update!(combined_assessed_capital: data[:assessed_capital] + partner_data[:assessed_capital])
       else
-        assessment.capital_summary.update!(combined_assessed_capital: assessment.capital_summary.assessed_capital)
+        assessment.capital_summary.update!(combined_assessed_capital: data[:assessed_capital])
       end
-      Assessors::CapitalAssessor.call(assessment.capital_summary, assessment.capital_summary.combined_assessed_capital)
+      contribution = Assessors::CapitalAssessor.call(assessment.capital_summary, assessment.capital_summary.combined_assessed_capital)
       CapitalSubtotals.new(
-        applicant_capital_subtotals: PersonCapitalSubtotals.new(total_vehicle: data[:total_vehicle]),
-        partner_capital_subtotals: (PersonCapitalSubtotals.new(total_vehicle: partner_data[:total_vehicle]) if assessment.partner.present?),
+        applicant_capital_subtotals: PersonCapitalSubtotals.new(data),
+        partner_capital_subtotals: (PersonCapitalSubtotals.new(partner_data) if assessment.partner.present?),
+        capital_contribution: contribution,
       )
     end
 

--- a/app/services/collators/capital_collator.rb
+++ b/app/services/collators/capital_collator.rb
@@ -1,17 +1,5 @@
 module Collators
   class CapitalCollator
-    RETURN_VALUES = {
-      total_liquid: "liquid_capital",
-      total_non_liquid: "non_liquid_capital",
-      total_vehicle: "vehicles",
-      total_mortgage_allowance: "property_maximum_mortgage_allowance_threshold",
-      total_property: "property",
-      pensioner_capital_disregard: "pensioner_capital_disregard",
-      subject_matter_of_dispute_disregard: "subject_matter_of_dispute_disregard",
-      total_capital: "total_capital",
-      assessed_capital: "assessed_capital",
-    }.freeze
-
     class << self
       def call(submission_date:, capital_summary:, pensioner_capital_disregard:, maximum_subject_matter_of_dispute_disregard:)
         new(submission_date:, capital_summary:, pensioner_capital_disregard:, maximum_subject_matter_of_dispute_disregard:).call
@@ -27,7 +15,18 @@ module Collators
 
     def call
       perform_assessments
-      RETURN_VALUES.deep_transform_values { |value| send(value) }
+
+      PersonCapitalSubtotals.new(
+        total_liquid: @liquid_capital,
+        total_non_liquid: @non_liquid_capital,
+        total_vehicle: @vehicles,
+        total_mortgage_allowance: property_maximum_mortgage_allowance_threshold,
+        total_property: @property,
+        pensioner_capital_disregard: @pensioner_capital_disregard,
+        subject_matter_of_dispute_disregard: @subject_matter_of_dispute_disregard,
+        total_capital: @total_capital,
+        assessed_capital: @assessed_capital,
+      )
     end
 
   private
@@ -37,21 +36,12 @@ module Collators
       @non_liquid_capital = Assessors::NonLiquidCapitalAssessor.call(@capital_summary)
       @property = Calculators::PropertyCalculator.call(submission_date: @submission_date, capital_summary: @capital_summary)
       @vehicles = Assessors::VehicleAssessor.call(@capital_summary.vehicles, @submission_date)
-    end
-
-    attr_reader :pensioner_capital_disregard, :liquid_capital, :non_liquid_capital, :property, :vehicles
-
-    def assessed_capital
-      total_capital - pensioner_capital_disregard - subject_matter_of_dispute_disregard
-    end
-
-    def subject_matter_of_dispute_disregard
-      Calculators::SubjectMatterOfDisputeDisregardCalculator.new(capital_summary: @capital_summary,
-                                                                 maximum_disregard: @maximum_subject_matter_of_dispute_disregard).value
-    end
-
-    def total_capital
-      @total_capital ||= liquid_capital + non_liquid_capital + vehicles + property
+      @subject_matter_of_dispute_disregard = Calculators::SubjectMatterOfDisputeDisregardCalculator.new(
+        capital_summary: @capital_summary,
+        maximum_disregard: @maximum_subject_matter_of_dispute_disregard,
+      ).value
+      @total_capital = @liquid_capital + @non_liquid_capital + @vehicles + @property
+      @assessed_capital = @total_capital - @pensioner_capital_disregard - @subject_matter_of_dispute_disregard
     end
 
     def property_maximum_mortgage_allowance_threshold

--- a/app/services/decorators/v5/capital_result_decorator.rb
+++ b/app/services/decorators/v5/capital_result_decorator.rb
@@ -1,10 +1,11 @@
 module Decorators
   module V5
     class CapitalResultDecorator
-      def initialize(summary, person_capital_subtotals, capital_contribution)
+      def initialize(summary, person_capital_subtotals, capital_contribution, combined_assessed_capital)
         @summary = summary
         @person_capital_subtotals = person_capital_subtotals
         @capital_contribution = capital_contribution
+        @combined_assessed_capital = combined_assessed_capital
       end
 
       def as_json
@@ -23,8 +24,8 @@ module Decorators
           total_property: @person_capital_subtotals.total_property.to_f,
           total_mortgage_allowance: @person_capital_subtotals.total_mortgage_allowance.to_f,
           total_capital: @person_capital_subtotals.total_capital.to_f,
-          pensioner_capital_disregard: summary.pensioner_capital_disregard.to_f,
-          subject_matter_of_dispute_disregard: summary.subject_matter_of_dispute_disregard.to_f,
+          pensioner_capital_disregard: @person_capital_subtotals.pensioner_capital_disregard.to_f,
+          subject_matter_of_dispute_disregard: @person_capital_subtotals.subject_matter_of_dispute_disregard.to_f,
           capital_contribution: @capital_contribution,
           assessed_capital: @person_capital_subtotals.assessed_capital.to_f,
         }
@@ -32,14 +33,12 @@ module Decorators
 
     private
 
-      attr_reader :summary
-
       def proceeding_types
-        ProceedingTypesResultDecorator.new(summary).as_json
+        ProceedingTypesResultDecorator.new(@summary).as_json
       end
 
       def combined_assessed_capital
-        summary.combined_assessed_capital.to_f
+        @combined_assessed_capital.to_f
       end
 
       def combined_capital_contribution

--- a/app/services/decorators/v5/capital_result_decorator.rb
+++ b/app/services/decorators/v5/capital_result_decorator.rb
@@ -1,9 +1,10 @@
 module Decorators
   module V5
     class CapitalResultDecorator
-      def initialize(summary, person_capital_subtotals)
+      def initialize(summary, person_capital_subtotals, capital_contribution)
         @summary = summary
         @person_capital_subtotals = person_capital_subtotals
+        @capital_contribution = capital_contribution
       end
 
       def as_json
@@ -16,16 +17,16 @@ module Decorators
 
       def basic_attributes
         {
-          total_liquid: summary.total_liquid.to_f,
-          total_non_liquid: summary.total_non_liquid.to_f,
+          total_liquid: @person_capital_subtotals.total_liquid.to_f,
+          total_non_liquid: @person_capital_subtotals.total_non_liquid.to_f,
           total_vehicle: @person_capital_subtotals.total_vehicle.to_f,
-          total_property: summary.total_property.to_f,
-          total_mortgage_allowance: summary.total_mortgage_allowance.to_f,
-          total_capital: summary.total_capital.to_f,
+          total_property: @person_capital_subtotals.total_property.to_f,
+          total_mortgage_allowance: @person_capital_subtotals.total_mortgage_allowance.to_f,
+          total_capital: @person_capital_subtotals.total_capital.to_f,
           pensioner_capital_disregard: summary.pensioner_capital_disregard.to_f,
           subject_matter_of_dispute_disregard: summary.subject_matter_of_dispute_disregard.to_f,
-          capital_contribution: summary.capital_contribution.to_f,
-          assessed_capital: summary.assessed_capital.to_f,
+          capital_contribution: @capital_contribution,
+          assessed_capital: @person_capital_subtotals.assessed_capital.to_f,
         }
       end
 
@@ -42,7 +43,7 @@ module Decorators
       end
 
       def combined_capital_contribution
-        summary.capital_contribution.to_f
+        @capital_contribution
       end
     end
   end

--- a/app/services/decorators/v5/result_summary_decorator.rb
+++ b/app/services/decorators/v5/result_summary_decorator.rb
@@ -29,7 +29,8 @@ module Decorators
           partner_disposable_income:,
           capital: CapitalResultDecorator.new(capital_summary,
                                               @calculation_output.capital_subtotals.applicant_capital_subtotals,
-                                              @calculation_output.capital_subtotals.capital_contribution.to_f).as_json,
+                                              @calculation_output.capital_subtotals.capital_contribution.to_f,
+                                              @calculation_output.capital_subtotals.combined_assessed_capital.to_f).as_json,
           partner_capital:,
         }
       end
@@ -53,7 +54,7 @@ module Decorators
 
         CapitalResultDecorator.new(assessment.partner_capital_summary,
                                    @calculation_output.capital_subtotals&.partner_capital_subtotals,
-                                   0).as_json
+                                   0, 0).as_json
       end
     end
   end

--- a/app/services/decorators/v5/result_summary_decorator.rb
+++ b/app/services/decorators/v5/result_summary_decorator.rb
@@ -17,7 +17,7 @@ module Decorators
         {
           overall_result: {
             result: @assessment.assessment_result,
-            capital_contribution: capital_summary.capital_contribution.to_f,
+            capital_contribution: @calculation_output.capital_subtotals.capital_contribution.to_f,
             income_contribution: disposable_income_summary.income_contribution.to_f,
             proceeding_types: ProceedingTypesResultDecorator.new(assessment).as_json,
           },
@@ -28,7 +28,8 @@ module Decorators
                                                                  partner_present: assessment.partner.present?).as_json,
           partner_disposable_income:,
           capital: CapitalResultDecorator.new(capital_summary,
-                                              @calculation_output.capital_subtotals.applicant_capital_subtotals).as_json,
+                                              @calculation_output.capital_subtotals.applicant_capital_subtotals,
+                                              @calculation_output.capital_subtotals.capital_contribution.to_f).as_json,
           partner_capital:,
         }
       end
@@ -51,7 +52,8 @@ module Decorators
         return unless assessment.partner
 
         CapitalResultDecorator.new(assessment.partner_capital_summary,
-                                   @calculation_output.capital_subtotals&.partner_capital_subtotals).as_json
+                                   @calculation_output.capital_subtotals&.partner_capital_subtotals,
+                                   0).as_json
       end
     end
   end

--- a/app/services/remark_generators/orchestrator.rb
+++ b/app/services/remark_generators/orchestrator.rb
@@ -8,12 +8,13 @@ module RemarkGenerators
 
     delegate :outgoings, to: :disposable_income_summary
 
-    def self.call(assessment)
-      new(assessment).call
+    def self.call(assessment, assessed_capital)
+      new(assessment, assessed_capital).call
     end
 
-    def initialize(assessment)
+    def initialize(assessment, assessed_capital)
       @assessment = assessment
+      @assessed_capital = assessed_capital
     end
 
     def call
@@ -61,7 +62,7 @@ module RemarkGenerators
     end
 
     def check_residual_balances
-      ResidualBalanceChecker.call(@assessment)
+      ResidualBalanceChecker.call(@assessment, @assessed_capital)
     end
 
     def check_flags

--- a/app/services/remark_generators/orchestrator.rb
+++ b/app/services/remark_generators/orchestrator.rb
@@ -62,7 +62,7 @@ module RemarkGenerators
     end
 
     def check_residual_balances
-      ResidualBalanceChecker.call(@assessment, @assessed_capital)
+      ResidualBalanceChecker.call(@assessment, @assessed_capital) if @assessed_capital
     end
 
     def check_flags

--- a/app/services/remark_generators/residual_balance_checker.rb
+++ b/app/services/remark_generators/residual_balance_checker.rb
@@ -1,11 +1,12 @@
 module RemarkGenerators
   class ResidualBalanceChecker
-    def self.call(assessment)
-      new(assessment).call
+    def self.call(assessment, assessed_capital)
+      new(assessment, assessed_capital).call
     end
 
-    def initialize(assessment)
+    def initialize(assessment, assessed_capital)
       @assessment = assessment
+      @assessed_capital = assessed_capital
     end
 
     def call
@@ -21,7 +22,7 @@ module RemarkGenerators
     end
 
     def capital_exceeds_lower_threshold?
-      assessment.capital_summary.assessed_capital > lower_capital_threshold
+      @assessed_capital.to_f > lower_capital_threshold
     end
 
     def populate_remarks

--- a/app/services/remark_generators/residual_balance_checker.rb
+++ b/app/services/remark_generators/residual_balance_checker.rb
@@ -22,7 +22,7 @@ module RemarkGenerators
     end
 
     def capital_exceeds_lower_threshold?
-      @assessed_capital.to_f > lower_capital_threshold
+      @assessed_capital > lower_capital_threshold
     end
 
     def populate_remarks

--- a/app/services/workflows/main_workflow.rb
+++ b/app/services/workflows/main_workflow.rb
@@ -7,7 +7,7 @@ module Workflows
                            else
                              NonPassportedWorkflow.call(assessment)
                            end
-      RemarkGenerators::Orchestrator.call(assessment, assessment.capital_summary.combined_assessed_capital)
+      RemarkGenerators::Orchestrator.call(assessment, calculation_output.capital_subtotals.combined_assessed_capital)
       Assessors::MainAssessor.call(assessment)
       calculation_output
     end

--- a/app/services/workflows/main_workflow.rb
+++ b/app/services/workflows/main_workflow.rb
@@ -7,7 +7,7 @@ module Workflows
                            else
                              NonPassportedWorkflow.call(assessment)
                            end
-      RemarkGenerators::Orchestrator.call(assessment)
+      RemarkGenerators::Orchestrator.call(assessment, assessment.capital_summary.combined_assessed_capital)
       Assessors::MainAssessor.call(assessment)
       calculation_output
     end

--- a/db/migrate/20230206104737_remove_columns_from_capital_summaries.rb
+++ b/db/migrate/20230206104737_remove_columns_from_capital_summaries.rb
@@ -1,0 +1,13 @@
+class RemoveColumnsFromCapitalSummaries < ActiveRecord::Migration[7.0]
+  def change
+    change_table :capital_summaries, bulk: true do |t|
+      t.remove(:assessed_capital,
+               :assessment_result,
+               :capital_contribution,
+               :total_capital,
+               :total_liquid,
+               :total_mortgage_allowance,
+               :total_non_liquid, type: :decimal, null: false, default: 0)
+    end
+  end
+end

--- a/db/migrate/20230206122959_remove_more_columns_from_capital_summaries.rb
+++ b/db/migrate/20230206122959_remove_more_columns_from_capital_summaries.rb
@@ -1,0 +1,14 @@
+class RemoveMoreColumnsFromCapitalSummaries < ActiveRecord::Migration[7.0]
+  def change
+    change_table :capital_summaries, bulk: true do |t|
+      t.remove(:total_property,
+               :upper_threshold,
+               :lower_threshold,
+               :pensioner_capital_disregard,
+               :subject_matter_of_dispute_disregard,
+               type: :decimal, null: false, default: 0)
+      t.remove(:combined_assessed_capital,
+               type: :decimal, null: true, default: nil)
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_02_06_104737) do
+ActiveRecord::Schema[7.0].define(version: 2023_02_06_122959) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -68,15 +68,9 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_06_104737) do
 
   create_table "capital_summaries", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "assessment_id"
-    t.decimal "total_property", default: "0.0", null: false
-    t.decimal "pensioner_capital_disregard", default: "0.0", null: false
-    t.decimal "lower_threshold", default: "0.0", null: false
-    t.decimal "upper_threshold", default: "0.0", null: false
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
-    t.decimal "subject_matter_of_dispute_disregard", default: "0.0", null: false
     t.string "type", default: "ApplicantCapitalSummary"
-    t.decimal "combined_assessed_capital"
     t.index ["assessment_id"], name: "index_capital_summaries_on_assessment_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_31_154602) do
+ActiveRecord::Schema[7.0].define(version: 2023_02_06_104737) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -68,17 +68,10 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_31_154602) do
 
   create_table "capital_summaries", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "assessment_id"
-    t.decimal "total_liquid", default: "0.0", null: false
-    t.decimal "total_non_liquid", default: "0.0", null: false
     t.decimal "total_property", default: "0.0", null: false
-    t.decimal "total_mortgage_allowance", default: "0.0", null: false
-    t.decimal "total_capital", default: "0.0", null: false
     t.decimal "pensioner_capital_disregard", default: "0.0", null: false
-    t.decimal "assessed_capital", default: "0.0", null: false
-    t.decimal "capital_contribution", default: "0.0", null: false
     t.decimal "lower_threshold", default: "0.0", null: false
     t.decimal "upper_threshold", default: "0.0", null: false
-    t.string "assessment_result", default: "pending", null: false
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
     t.decimal "subject_matter_of_dispute_disregard", default: "0.0", null: false

--- a/spec/services/collators/capital_collator_spec.rb
+++ b/spec/services/collators/capital_collator_spec.rb
@@ -19,13 +19,13 @@ module Collators
       end
 
       it "always returns a hash" do
-        expect(collator).to be_a Hash
+        expect(collator).to be_a PersonCapitalSubtotals
       end
 
       context "liquid capital" do
         it "calls LiquidCapitalAssessment and updates capital summary with the result" do
           allow(Assessors::LiquidCapitalAssessor).to receive(:call).and_return(145.83)
-          expect(collator[:total_liquid]).to eq 145.83
+          expect(collator.total_liquid).to eq 145.83
         end
       end
 
@@ -35,7 +35,7 @@ module Collators
           allow(Calculators::PropertyCalculator).to receive(:new).and_return(property_service)
           allow(property_service).to receive(:call).and_return(23_000.0)
           collator
-          expect(collator[:total_property]).to eq 23_000.0
+          expect(collator.total_property).to eq 23_000.0
         end
       end
 
@@ -43,7 +43,7 @@ module Collators
         it "instantiates and calls the Vehicle Assesment service" do
           allow(Assessors::VehicleAssessor).to receive(:call).and_return(2_500.0)
           collator
-          expect(collator[:total_vehicle]).to eq 2_500.0
+          expect(collator.total_vehicle).to eq 2_500.0
         end
       end
 
@@ -51,7 +51,7 @@ module Collators
         it "instantiates and calls NonLiquidCapitalAssessment" do
           allow(Assessors::NonLiquidCapitalAssessor).to receive(:call).and_return(500)
           collator
-          expect(collator[:total_non_liquid]).to eq 500.0
+          expect(collator.total_non_liquid).to eq 500.0
         end
       end
 
@@ -70,15 +70,15 @@ module Collators
 
           collator
 
-          expect(collator[:total_liquid]).to eq 145.83
-          expect(collator[:total_non_liquid]).to eq 500
-          expect(collator[:total_vehicle]).to eq 2_500
-          expect(collator[:total_property]).to eq 23_000
-          expect(collator[:total_mortgage_allowance]).to eq 999_999_999_999
-          expect(collator[:total_capital]).to eq 26_145.83
-          expect(collator[:pensioner_capital_disregard]).to eq 100_000
-          expect(collator[:subject_matter_of_dispute_disregard]).to eq 0
-          expect(collator[:assessed_capital]).to eq(-73_854.17)
+          expect(collator.total_liquid).to eq 145.83
+          expect(collator.total_non_liquid).to eq 500
+          expect(collator.total_vehicle).to eq 2_500
+          expect(collator.total_property).to eq 23_000
+          expect(collator.total_mortgage_allowance).to eq 999_999_999_999
+          expect(collator.total_capital).to eq 26_145.83
+          expect(collator.pensioner_capital_disregard).to eq 100_000
+          expect(collator.subject_matter_of_dispute_disregard).to eq 0
+          expect(collator.assessed_capital).to eq(-73_854.17)
         end
       end
     end

--- a/spec/services/creators/assessment_creator_spec.rb
+++ b/spec/services/creators/assessment_creator_spec.rb
@@ -74,17 +74,8 @@ module Creators
           let(:capital_summary) { CapitalSummary.first }
 
           it "creates all fields as zero" do
-            expect(capital_summary.total_liquid).to eq 0.0
-            expect(capital_summary.total_non_liquid).to eq 0.0
-            expect(capital_summary.total_property).to eq 0.0
-            expect(capital_summary.total_mortgage_allowance).to eq 0.0
-            expect(capital_summary.pensioner_capital_disregard).to eq 0.0
-            expect(capital_summary.assessed_capital).to eq 0.0
-            expect(capital_summary.capital_contribution).to eq 0.0
-            expect(capital_summary.total_capital).to eq 0.0
             expect(capital_summary.pensioner_capital_disregard).to eq 0.0
             expect(capital_summary.lower_threshold).to eq 0.0
-            expect(capital_summary.assessed_capital).to eq 0.0
             expect(capital_summary.upper_threshold).to eq 0.0
           end
         end
@@ -139,17 +130,8 @@ module Creators
           let(:capital_summary) { CapitalSummary.first }
 
           it "creates all fields as zero" do
-            expect(capital_summary.total_liquid).to eq 0.0
-            expect(capital_summary.total_non_liquid).to eq 0.0
-            expect(capital_summary.total_property).to eq 0.0
-            expect(capital_summary.total_mortgage_allowance).to eq 0.0
-            expect(capital_summary.pensioner_capital_disregard).to eq 0.0
-            expect(capital_summary.assessed_capital).to eq 0.0
-            expect(capital_summary.capital_contribution).to eq 0.0
-            expect(capital_summary.total_capital).to eq 0.0
             expect(capital_summary.pensioner_capital_disregard).to eq 0.0
             expect(capital_summary.lower_threshold).to eq 0.0
-            expect(capital_summary.assessed_capital).to eq 0.0
             expect(capital_summary.upper_threshold).to eq 0.0
           end
         end

--- a/spec/services/creators/assessment_creator_spec.rb
+++ b/spec/services/creators/assessment_creator_spec.rb
@@ -68,18 +68,6 @@ module Creators
           expect { creator.success? }.to change(CapitalSummary, :count).by(1)
         end
 
-        context "capital summary record" do
-          before { creator.success? }
-
-          let(:capital_summary) { CapitalSummary.first }
-
-          it "creates all fields as zero" do
-            expect(capital_summary.pensioner_capital_disregard).to eq 0.0
-            expect(capital_summary.lower_threshold).to eq 0.0
-            expect(capital_summary.upper_threshold).to eq 0.0
-          end
-        end
-
         it "has no errors" do
           expect(creator.errors).to be_empty
         end
@@ -122,18 +110,6 @@ module Creators
 
         it "creates a CapitalSummary record" do
           expect { creator.success? }.to change(CapitalSummary, :count).by(1)
-        end
-
-        context "capital summary record" do
-          before { creator.success? }
-
-          let(:capital_summary) { CapitalSummary.first }
-
-          it "creates all fields as zero" do
-            expect(capital_summary.pensioner_capital_disregard).to eq 0.0
-            expect(capital_summary.lower_threshold).to eq 0.0
-            expect(capital_summary.upper_threshold).to eq 0.0
-          end
         end
 
         it "has no errors" do

--- a/spec/services/decorators/v5/capital_result_decorator_spec.rb
+++ b/spec/services/decorators/v5/capital_result_decorator_spec.rb
@@ -13,12 +13,9 @@ module Decorators
       end
       let(:pr_hash) { [%w[DA003 A], %w[SE014 Z]] }
       let(:summary) do
-        create :capital_summary,
-               assessment:,
-               pensioner_capital_disregard: 10_000,
-               subject_matter_of_dispute_disregard: 3_000,
-               combined_assessed_capital: 12_000
+        create :capital_summary, assessment:
       end
+
       let(:subtotals) do
         PersonCapitalSubtotals.new(total_vehicle: 3500,
                                    total_liquid: 9_355.23,
@@ -26,9 +23,12 @@ module Decorators
                                    total_property: 835_500,
                                    total_mortgage_allowance: 750_000,
                                    total_capital: 24_000,
-                                   assessed_capital: 9_355)
+                                   assessed_capital: 9_355,
+                                   pensioner_capital_disregard: 10_000,
+                                   subject_matter_of_dispute_disregard: 3_000)
       end
       let(:capital_contribution) { 0 }
+      let(:combined_assessed_capital) { 12_000 }
 
       let(:expected_result) do
         {
@@ -75,7 +75,7 @@ module Decorators
         end
       end
 
-      subject(:decorator) { described_class.new(assessment.capital_summary, subtotals, capital_contribution).as_json }
+      subject(:decorator) { described_class.new(assessment.capital_summary, subtotals, capital_contribution, combined_assessed_capital).as_json }
 
       describe "#as_json" do
         it "returns the expected structure" do

--- a/spec/services/decorators/v5/capital_result_decorator_spec.rb
+++ b/spec/services/decorators/v5/capital_result_decorator_spec.rb
@@ -15,18 +15,20 @@ module Decorators
       let(:summary) do
         create :capital_summary,
                assessment:,
-               total_liquid: 9_355.23,
-               total_non_liquid: 12_553.22,
-               total_property: 835_500,
-               total_mortgage_allowance: 750_000,
-               total_capital: 24_000,
                pensioner_capital_disregard: 10_000,
                subject_matter_of_dispute_disregard: 3_000,
-               capital_contribution: 0.0,
-               assessed_capital: 9_355,
                combined_assessed_capital: 12_000
       end
-      let(:subtotals) { PersonCapitalSubtotals.new(total_vehicle: 3500) }
+      let(:subtotals) do
+        PersonCapitalSubtotals.new(total_vehicle: 3500,
+                                   total_liquid: 9_355.23,
+                                   total_non_liquid: 12_553.22,
+                                   total_property: 835_500,
+                                   total_mortgage_allowance: 750_000,
+                                   total_capital: 24_000,
+                                   assessed_capital: 9_355)
+      end
+      let(:capital_contribution) { 0 }
 
       let(:expected_result) do
         {
@@ -73,7 +75,7 @@ module Decorators
         end
       end
 
-      subject(:decorator) { described_class.new(assessment.capital_summary, subtotals).as_json }
+      subject(:decorator) { described_class.new(assessment.capital_summary, subtotals, capital_contribution).as_json }
 
       describe "#as_json" do
         it "returns the expected structure" do

--- a/spec/services/remark_generators/orchestrator_spec.rb
+++ b/spec/services/remark_generators/orchestrator_spec.rb
@@ -35,9 +35,9 @@ module RemarkGenerators
       expect(FrequencyChecker).to receive(:call).with(assessment, legal_aid_outgoings)
       expect(FrequencyChecker).to receive(:call).with(assessment, employment_payments, :date)
 
-      expect(ResidualBalanceChecker).to receive(:call).with(assessment)
+      expect(ResidualBalanceChecker).to receive(:call).with(assessment, 0)
 
-      described_class.call(assessment)
+      described_class.call(assessment, 0)
     end
   end
 end

--- a/spec/services/remark_generators/residual_balance_checker_spec.rb
+++ b/spec/services/remark_generators/residual_balance_checker_spec.rb
@@ -3,19 +3,20 @@ require "rails_helper"
 module RemarkGenerators
   RSpec.describe ResidualBalanceChecker do
     let(:assessment) { create :assessment, capital_summary: }
-    let(:capital_summary) { create :capital_summary, :with_eligibilities, lower_threshold: 3000, assessed_capital: 4000 }
+    let(:capital_summary) { create :capital_summary, :with_eligibilities, lower_threshold: 3000 }
+    let(:assessed_capital) { 4000 }
 
     context "when a residual balance exists and assessed capital is above the lower threshold" do
       before { create :liquid_capital_item, description: "Current accounts", value: 100, capital_summary: }
 
       it "adds the remark when a residual balance exists" do
         expect_any_instance_of(Remarks).to receive(:add).with(:current_account_balance, :residual_balance, [])
-        described_class.call(assessment)
+        described_class.call(assessment, assessed_capital)
       end
 
       it "stores the changed the remarks class on the assessment" do
         original_remarks = assessment.remarks.as_json
-        described_class.call(assessment)
+        described_class.call(assessment, assessed_capital)
         expect(assessment.reload.remarks.as_json).not_to eq original_remarks
       end
     end
@@ -23,17 +24,17 @@ module RemarkGenerators
     context "when there is no residual balance" do
       it "does not update the remarks class" do
         original_remarks = assessment.remarks.as_json
-        described_class.call(assessment)
+        described_class.call(assessment, assessed_capital)
         expect(assessment.reload.remarks.as_json).to eq original_remarks
       end
     end
 
     context "when capital assessment is below the lower threshold" do
-      let(:capital_summary) { create :capital_summary, :with_eligibilities, lower_threshold: 3000, assessed_capital: 1000 }
+      let(:capital_summary) { create :capital_summary, :with_eligibilities, lower_threshold: 3000 }
 
       it "does not update the remarks class" do
         original_remarks = assessment.remarks.as_json
-        described_class.call(assessment)
+        described_class.call(assessment, 0)
         expect(assessment.reload.remarks.as_json).to eq original_remarks
       end
     end
@@ -41,11 +42,11 @@ module RemarkGenerators
     context "when there is no residual balance and assessed capital is below the lower threshold" do
       before { create :liquid_capital_item, description: "Current accounts", value: 0, capital_summary: }
 
-      let(:capital_summary) { create :capital_summary, :with_eligibilities, lower_threshold: 3000, assessed_capital: 1000 }
+      let(:capital_summary) { create :capital_summary, :with_eligibilities, lower_threshold: 3000 }
 
       it "does not update the remarks class" do
         original_remarks = assessment.remarks.as_json
-        described_class.call(assessment)
+        described_class.call(assessment, assessed_capital)
         expect(assessment.reload.remarks.as_json).to eq original_remarks
       end
     end
@@ -59,7 +60,7 @@ module RemarkGenerators
 
         it "adds the remark when a residual balance exists" do
           expect_any_instance_of(Remarks).to receive(:add).with(:current_account_balance, :residual_balance, [])
-          described_class.call(assessment)
+          described_class.call(assessment, assessed_capital)
         end
       end
 
@@ -71,7 +72,7 @@ module RemarkGenerators
 
         it "does not update the remarks class" do
           original_remarks = assessment.remarks.as_json
-          described_class.call(assessment)
+          described_class.call(assessment, assessed_capital)
           expect(assessment.reload.remarks.as_json).to eq original_remarks
         end
       end

--- a/spec/services/remark_generators/residual_balance_checker_spec.rb
+++ b/spec/services/remark_generators/residual_balance_checker_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 module RemarkGenerators
   RSpec.describe ResidualBalanceChecker do
     let(:assessment) { create :assessment, capital_summary: }
-    let(:capital_summary) { create :capital_summary, :with_eligibilities, lower_threshold: 3000 }
+    let(:capital_summary) { create :capital_summary, :with_eligibilities }
     let(:assessed_capital) { 4000 }
 
     context "when a residual balance exists and assessed capital is above the lower threshold" do
@@ -30,7 +30,7 @@ module RemarkGenerators
     end
 
     context "when capital assessment is below the lower threshold" do
-      let(:capital_summary) { create :capital_summary, :with_eligibilities, lower_threshold: 3000 }
+      let(:capital_summary) { create :capital_summary, :with_eligibilities }
 
       it "does not update the remarks class" do
         original_remarks = assessment.remarks.as_json
@@ -42,7 +42,7 @@ module RemarkGenerators
     context "when there is no residual balance and assessed capital is below the lower threshold" do
       before { create :liquid_capital_item, description: "Current accounts", value: 0, capital_summary: }
 
-      let(:capital_summary) { create :capital_summary, :with_eligibilities, lower_threshold: 3000 }
+      let(:capital_summary) { create :capital_summary, :with_eligibilities }
 
       it "does not update the remarks class" do
         original_remarks = assessment.remarks.as_json

--- a/spec/services/workflows/main_workflow_spec.rb
+++ b/spec/services/workflows/main_workflow_spec.rb
@@ -22,12 +22,12 @@ module Workflows
 
       it "calls PassportedWorkflow" do
         allow(Assessors::MainAssessor).to receive(:call)
-        expect(PassportedWorkflow).to receive(:call).with(assessment)
+        allow(PassportedWorkflow).to receive(:call).with(assessment).and_return(CalculationOutput.new)
         workflow_call
       end
 
       it "calls MainAssessor" do
-        allow(PassportedWorkflow).to receive(:call)
+        allow(PassportedWorkflow).to receive(:call).and_return(CalculationOutput.new)
         expect(Assessors::MainAssessor).to receive(:call).with(assessment)
         workflow_call
       end
@@ -40,12 +40,12 @@ module Workflows
 
       it "calls PassportedWorkflow" do
         allow(Assessors::MainAssessor).to receive(:call)
-        expect(NonPassportedWorkflow).to receive(:call).with(assessment)
+        allow(NonPassportedWorkflow).to receive(:call).with(assessment).and_return(CalculationOutput.new)
         workflow_call
       end
 
       it "calls MainAssessor" do
-        allow(NonPassportedWorkflow).to receive(:call)
+        allow(NonPassportedWorkflow).to receive(:call).and_return(CalculationOutput.new)
         expect(Assessors::MainAssessor).to receive(:call).with(assessment)
         workflow_call
       end
@@ -71,9 +71,9 @@ module Workflows
           expect(Utilities::ProceedingTypeThresholdPopulator).to receive(:call).with(assessment)
 
           allow(Creators::EligibilitiesCreator).to receive(:call).with(assessment)
-          allow(NonPassportedWorkflow).to receive(:call).with(assessment)
+          allow(NonPassportedWorkflow).to receive(:call).with(assessment).and_return(CalculationOutput.new)
           allow(Assessors::MainAssessor).to receive(:call).with(assessment)
-          allow(RemarkGenerators::Orchestrator).to receive(:call).with(assessment)
+          allow(RemarkGenerators::Orchestrator).to receive(:call).with(assessment, nil)
 
           workflow_call
         end
@@ -82,9 +82,9 @@ module Workflows
           expect(Creators::EligibilitiesCreator).to receive(:call).with(assessment)
 
           allow(Utilities::ProceedingTypeThresholdPopulator).to receive(:call).with(assessment)
-          allow(NonPassportedWorkflow).to receive(:call).with(assessment)
+          allow(NonPassportedWorkflow).to receive(:call).with(assessment).and_return(CalculationOutput.new)
           allow(Assessors::MainAssessor).to receive(:call).with(assessment)
-          allow(RemarkGenerators::Orchestrator).to receive(:call).with(assessment)
+          allow(RemarkGenerators::Orchestrator).to receive(:call).with(assessment, nil)
 
           workflow_call
         end

--- a/spec/services/workflows/passported_workflow_spec.rb
+++ b/spec/services/workflows/passported_workflow_spec.rb
@@ -22,7 +22,7 @@ module Workflows
         expect(Collators::CapitalCollator).to receive(:call)
         result = workflow_call
         expect(result.capital_subtotals.applicant_capital_subtotals.total_vehicle).to eq 500
-        expect(capital_summary.reload).to have_matching_attributes(capital_data.except(:total_vehicle))
+        expect(capital_summary.reload).to have_matching_attributes(capital_data.slice(:pensioner_capital_disregard))
       end
 
       it "calls CapitalAssessor and updates capital summary record with result" do
@@ -43,8 +43,6 @@ module Workflows
           pensioner_capital_disregard: 90_000,
           total_capital: 14_045.38,
           assessed_capital: 0.0,
-          lower_threshold: 3_000.0,
-          upper_threshold: 8_000.0,
           capital_contribution: 0.0,
         }
       end

--- a/spec/services/workflows/passported_workflow_spec.rb
+++ b/spec/services/workflows/passported_workflow_spec.rb
@@ -13,6 +13,19 @@ module Workflows
     let(:applicant) { create :applicant, :with_qualifying_benefits }
     let(:capital_summary) { assessment.capital_summary }
     let(:gross_income_summary) { assessment.gross_income_summary }
+    let(:capital_data) do
+      PersonCapitalSubtotals.new(
+        total_liquid: 45.36,
+        total_non_liquid: 14_000.02,
+        total_vehicle: 500.0,
+        total_mortgage_allowance: 100_000.0,
+        total_property: 35_000,
+        pensioner_capital_disregard: 90_000,
+        total_capital: 14_045.38,
+        assessed_capital: 0.0,
+        capital_contribution: 0.0,
+      )
+    end
 
     describe ".call" do
       subject(:workflow_call) { described_class.call(assessment) }
@@ -21,8 +34,8 @@ module Workflows
         allow(Collators::CapitalCollator).to receive(:call).and_return(capital_data)
         expect(Collators::CapitalCollator).to receive(:call)
         result = workflow_call
-        expect(result.capital_subtotals.applicant_capital_subtotals.total_vehicle).to eq capital_data[:total_vehicle]
-        expect(result.capital_subtotals.combined_assessed_capital).to eq capital_data[:assessed_capital]
+        expect(result.capital_subtotals.applicant_capital_subtotals).to eq capital_data
+        expect(result.capital_subtotals.combined_assessed_capital).to eq capital_data.assessed_capital
       end
 
       it "calls CapitalAssessor and updates capital summary record with result" do
@@ -31,20 +44,6 @@ module Workflows
         expect(Assessors::CapitalAssessor).to receive(:call).and_call_original
         workflow_call
         expect(capital_summary.summarized_assessment_result).to eq :eligible
-      end
-
-      def capital_data
-        {
-          total_liquid: 45.36,
-          total_non_liquid: 14_000.02,
-          total_vehicle: 500.0,
-          total_mortgage_allowance: 100_000.0,
-          total_property: 35_000,
-          pensioner_capital_disregard: 90_000,
-          total_capital: 14_045.38,
-          assessed_capital: 0.0,
-          capital_contribution: 0.0,
-        }
       end
     end
   end

--- a/spec/services/workflows/passported_workflow_spec.rb
+++ b/spec/services/workflows/passported_workflow_spec.rb
@@ -17,12 +17,12 @@ module Workflows
     describe ".call" do
       subject(:workflow_call) { described_class.call(assessment) }
 
-      it "calls Capital collator and updates capital summary record" do
+      it "calls Capital collator and return some data" do
         allow(Collators::CapitalCollator).to receive(:call).and_return(capital_data)
         expect(Collators::CapitalCollator).to receive(:call)
         result = workflow_call
-        expect(result.capital_subtotals.applicant_capital_subtotals.total_vehicle).to eq 500
-        expect(capital_summary.reload).to have_matching_attributes(capital_data.slice(:pensioner_capital_disregard))
+        expect(result.capital_subtotals.applicant_capital_subtotals.total_vehicle).to eq capital_data[:total_vehicle]
+        expect(result.capital_subtotals.combined_assessed_capital).to eq capital_data[:assessed_capital]
       end
 
       it "calls CapitalAssessor and updates capital summary record with result" do


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/EL-658)

Move attributes to return object.
In addition to the properties listed on the ticket, it also made sense to remove:

- combined_assessed_capital
- pensioner_capital_disregard
- subject_matter_of_dispute_disregard

Also, as these fields are not actually used anywhere any more, I _did_ remove

- upper_threshold
- lower_threshold

(The actual thresholds are stored elsewhere)

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
