### PR TITLE
EL-670 monthly equivalent calculator bug - reset frequency

### DIFF
--- a/app/models/concerns/monthly_equivalent_calculator.rb
+++ b/app/models/concerns/monthly_equivalent_calculator.rb
@@ -17,6 +17,7 @@ module MonthlyEquivalentCalculator
 
   def calculate_monthly_equivalent(collection:, date_method: :payment_date, amount_method: :amount)
     @converter = nil # reset the converter each time it's used
+    @frequency = nil
     return 0.0 if collection.empty?
 
     @monthly_equivalent_calculator_collection = collection

--- a/spec/services/calculators/housing_costs_calculator_spec.rb
+++ b/spec/services/calculators/housing_costs_calculator_spec.rb
@@ -30,7 +30,6 @@ module Calculators
 
         calculator
         assessment.disposable_income_summary.reload
-        @assessment = assessment
       end
 
       context "when applicant has no dependants" do
@@ -237,6 +236,20 @@ module Calculators
           end
         end
 
+        context "with a different housing benefit frequency" do
+          let(:housing_benefit_amount) { 500.00 }
+          let(:housing_cost_type) { "rent" }
+
+          before {
+            create_housing_benefit_payments(housing_benefit_amount, dates: [4.weeks.ago, 3.weeks.ago, 2.weeks.ago, 1.week.ago, Date.current])
+          }
+
+          it "records the full monthly housing costs" do
+            expect(calculator.gross_housing_costs - monthly_cash_housing).to eq(1200.00)
+            expect(calculator.monthly_housing_benefit).to eq 833.33
+          end
+        end
+
         context "with housing benefit as a state_benefit" do
           let(:housing_benefit_amount) { 500.00 }
 
@@ -434,12 +447,13 @@ module Calculators
       end
     end
 
-    def create_housing_benefit_payments(amount)
+    def create_housing_benefit_payments(amount, dates: [2.months.ago, 1.month.ago, Date.current])
       housing_benefit_type = create :state_benefit_type, label: "housing_benefit"
       state_benefit = create :state_benefit, gross_income_summary: assessment.gross_income_summary, state_benefit_type: housing_benefit_type
-      [2.months.ago, 1.month.ago, Date.current].each do |pay_date|
+      dates.each do |pay_date|
         create :state_benefit_payment, state_benefit:, amount:, payment_date: pay_date
       end
+      assessment.gross_income_summary.reload
     end
   end
 end


### PR DESCRIPTION
This is a fix for an obscure edge-case where certain benefits are paid at different frequencies
