### PR TITLE
 Docker image size reduced 785MB -> 169MB

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,32 +1,30 @@
-FROM ruby:3.1.2-alpine3.16
-MAINTAINER apply for legal aid team
+FROM ruby:3.1.2-alpine3.16 as builder
 
 ENV RAILS_ENV production
 
 RUN set -ex
 
-RUN apk --no-cache add --virtual build-dependencies \
-                    build-base \
-                    postgresql-dev \
-&& apk --no-cache add postgresql-client
+RUN apk --no-cache add build-base \
+                       postgresql-dev
 
-RUN mkdir /myapp
-WORKDIR /myapp
-
-RUN adduser --disabled-password apply -u 1001
-
-COPY Gemfile /myapp/Gemfile
-COPY Gemfile.lock /myapp/Gemfile.lock
+COPY Gemfile Gemfile
+COPY Gemfile.lock Gemfile.lock
 
 RUN gem update --system
 RUN bundle config --local without test:development && bundle install
 
+
+FROM ruby:3.1.2-alpine3.16
+RUN apk --no-cache add postgresql-client
+
+COPY --from=builder /usr/local/bundle/ /usr/local/bundle/
 COPY . /myapp
 
-RUN apk del build-dependencies
+WORKDIR /myapp
 
 EXPOSE 3000
 
+RUN adduser --disabled-password apply -u 1001
 RUN chown -R apply:apply /myapp
 
 # expect ping environment variables


### PR DESCRIPTION
## What

Using multistage Dockerfile to reduce the Docker image size, by excluding from the final image: bundler and associated build packages.

Smaller image is good:
* quicker image download, and thus pod start-ups
* less attack surface

The "--virtual build-dependencies" trick wasn't working, since every CMD creates a layer in the image, so the trick only works if you delete the build dependencies again in the same CMD. Multistage dockerfile is the preferred method.

No Jira story.

Testing done on the command-line - not to the end, but seems ok:
```
% export CFE=https://docker-image-smaller-check-financial-partner-uat.cloud-platform.service.justice.gov.uk/

% curl -X POST $CFE/assessments -d '{"client_reference_id": "LA-FOO-BAR",  "submission_date": "2022-05-19", "level_of_representation": "certificated"}'

{"success":true,"assessment_id":"cf0bcd08-29f2-460a-b763-097dd0daee4e","errors":[]}%

% export ASSESSMENT_ID=$(curl -X POST -s $CFE/assessments -d '{"client_reference_id": "LA-FOO-BAR",  "submission_date": "2022-05-19", "level_of_representation": "certificated"}' | jq -r .assessment_id) && echo $ASSESSMENT_ID

5c71225b-f400-4e73-a565-d2aed005573b

% curl -X POST -s $CFE/assessments/$ASSESSMENT_ID/applicant -d '{"applicant": {
    "date_of_birth": "1992-07-22",
    "has_partner_opponent": false,
    "receives_qualifying_benefit": false}}'
curl -X POST -s $CFE/assessments/$ASSESSMENT_ID/proceeding_types -d '{"proceeding_types": [
    {"ccms_code": "DA005",
      "client_involvement_type": "A"},
    {"ccms_code": "SE013",
      "client_involvement_type": "I"}  ]}'
curl -X GET -s $CFE/assessments/$ASSESSMENT_ID | jq .

<html>
<head><title>403 Forbidden</title></head>
<body>
<center><h1>403 Forbidden</h1></center>
<hr><center>nginx</center>
</body>
</html>
<html>
<head><title>403 Forbidden</title></head>
<body>
<center><h1>403 Forbidden</h1></center>
<hr><center>nginx</center>
</body>
</html>
{
  "errors": [
    "You must add proceeding types and applicant to before calling for the assessment to be calculated"
  ],
  "success": false
}
```

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
