### PR TITLE
EL-719: Reduce threshold for clearing out old assessments

### DIFF
--- a/app/constants/cfe_constants.rb
+++ b/app/constants/cfe_constants.rb
@@ -91,5 +91,5 @@ module CFEConstants
 
   # Number of days before assessment is considered stale and eligible for deletion
   #
-  STALE_ASSESSMENT_THRESHOLD_DAYS = 30
+  STALE_ASSESSMENT_THRESHOLD_DAYS = 14
 end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/EL-719)

Clear out old assessments after 14 days instead of 30.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
