### PR TITLE
rename 'standard' to 'certificated' in cucumber tests

### DIFF
--- a/features/disputed_assets/disputed_capital_items.feature
+++ b/features/disputed_assets/disputed_capital_items.feature
@@ -2,7 +2,7 @@ Feature:
     "I have a disputed capital items"
 
     Scenario: A SMOD bank account whose value is entirely disregarded
-        Given I am undertaking a standard assessment with an applicant who receives passporting benefits
+        Given I am undertaking a certificated assessment with an applicant who receives passporting benefits
         And I add the following capital details for "bank_accounts" in the current assessment:
             | description  | value   | subject_matter_of_dispute |
             | Bank account | 5000.0  | true                      |
@@ -14,7 +14,7 @@ Feature:
             | assessed_capital                    | 0.0    |
 
     Scenario: A SMOD investment whose value is entirely disregarded
-        Given I am undertaking a standard assessment with an applicant who receives passporting benefits
+        Given I am undertaking a certificated assessment with an applicant who receives passporting benefits
         And I add the following capital details for "non_liquid_capital" in the current assessment:
             | description    | value   | subject_matter_of_dispute |
             | Investment     | 50000.0 | true                      |
@@ -28,7 +28,7 @@ Feature:
 
 
     Scenario: A SMOD bank account whose value is over the SMOD disregard limit
-        Given I am undertaking a standard assessment with an applicant who receives passporting benefits
+        Given I am undertaking a certificated assessment with an applicant who receives passporting benefits
         And I add the following capital details for "bank_accounts" in the current assessment:
             | description | value    | subject_matter_of_dispute |
             | Bank acc 1  | 150000.0 | true                      |
@@ -40,7 +40,7 @@ Feature:
             | assessed_capital                    | 50000.0  |
 
     Scenario: Two SMOD assets whose combined value is over the SMOD disregard limit
-        Given I am undertaking a standard assessment with an applicant who receives passporting benefits
+        Given I am undertaking a certificated assessment with an applicant who receives passporting benefits
         And I add the following capital details for "bank_accounts" in the current assessment:
             | description | value   | subject_matter_of_dispute |
             | Bank acc 1  | 50000.0 | true                      |

--- a/features/disputed_assets/disputed_property.feature
+++ b/features/disputed_assets/disputed_property.feature
@@ -2,7 +2,7 @@ Feature:
     "I have a property that is disputed"
 
     Scenario: A SMOD property where the value of the client's share of its equity is entirely disregarded
-        Given I am undertaking a standard assessment with an applicant who receives passporting benefits
+        Given I am undertaking a certificated assessment with an applicant who receives passporting benefits
         And I add the following main property details for the current assessment:
             | value                     | 150000 |
             | outstanding_mortgage      | 0      |
@@ -23,7 +23,7 @@ Feature:
             | assessed_capital                    | 0.0     |
 
     Scenario: The SMOD disregard is capped if the property is assessed as being worth more than £100k.
-        Given I am undertaking a standard assessment with an applicant who receives passporting benefits
+        Given I am undertaking a certificated assessment with an applicant who receives passporting benefits
         And I add the following main property details for the current assessment:
             | value                     | 250000 |
             | outstanding_mortgage      | 0      |
@@ -44,7 +44,7 @@ Feature:
             | assessed_capital                    | 42500.0  |
 
     Scenario: Disputed main and additional properties which, combined, are assessed as worth less than £100k
-        Given I am undertaking a standard assessment with an applicant who receives passporting benefits
+        Given I am undertaking a certificated assessment with an applicant who receives passporting benefits
         And I add the following main property details for the current assessment:
             | value                     | 250000 |
             | outstanding_mortgage      | 0      |

--- a/features/disputed_assets/disputed_vehicle.feature
+++ b/features/disputed_assets/disputed_vehicle.feature
@@ -2,7 +2,7 @@ Feature:
     "I have a vehicle that is disputed"
 
     Scenario: A SMOD vehicle whose assessed value is entirely disregarded
-        Given I am undertaking a standard assessment with an applicant who receives passporting benefits
+        Given I am undertaking a certificated assessment with an applicant who receives passporting benefits
         And I add the following vehicle details for the current assessment:
             | value                     | 18000      |
             | loan_amount_outstanding   | 0          |
@@ -21,7 +21,7 @@ Feature:
             | assessed_capital                    | 0.0     |
 
     Scenario: A SMOD vehicle whose assessed value is over the SMOD limit
-        Given I am undertaking a standard assessment with an applicant who receives passporting benefits
+        Given I am undertaking a certificated assessment with an applicant who receives passporting benefits
         And I add the following vehicle details for the current assessment:
             | value                     | 180000     |
             | loan_amount_outstanding   | 0          |
@@ -40,7 +40,7 @@ Feature:
             | assessed_capital                    | 80000.0  |
 
     Scenario: A SMOD vehicle whose assessed value is partially disregarded due to other SMOD assets reaching SMOD cap
-        Given I am undertaking a standard assessment with an applicant who receives passporting benefits
+        Given I am undertaking a certificated assessment with an applicant who receives passporting benefits
          And I add the following vehicle details for the current assessment:
             | value                     | 18000      |
             | loan_amount_outstanding   | 0          |

--- a/features/partner/partner_assessment.feature
+++ b/features/partner/partner_assessment.feature
@@ -2,7 +2,7 @@ Feature:
   "Applicant has a partner"
 
   Scenario: An applicant with a partner who has additional property (capital)
-    Given I am undertaking a standard assessment with an applicant who receives passporting benefits
+    Given I am undertaking a certificated assessment with an applicant who receives passporting benefits
     And I add the following main property details for the current assessment:
       | value                     | 150000 |
       | outstanding_mortgage      | 145000 |
@@ -35,7 +35,7 @@ Feature:
       | assessment_result            | contribution_required |
 
 Scenario: An applicant and partner's combined capital is over the lower threshold
-  Given I am undertaking a standard assessment with an applicant who receives passporting benefits
+  Given I am undertaking a certificated assessment with an applicant who receives passporting benefits
     And I add the following capital details for "bank_accounts" in the current assessment:
       | description  | value   | subject_matter_of_dispute |
       | Bank account | 2000.0  | false                     |
@@ -49,7 +49,7 @@ Scenario: An applicant and partner's combined capital is over the lower threshol
       | capital contribution         | 1000.0                |
 
   Scenario: An unemployed applicant with an employed partner
-    Given I am undertaking a standard assessment with a pensioner applicant who is not passported
+    Given I am undertaking a certificated assessment with a pensioner applicant who is not passported
     And I add the following employment details for the partner:
       | client_id |     date     |  gross | benefits_in_kind  | tax   | national_insurance | net_employment_income |
       |     C     |  2022-07-22  | 500.50 |       0           | 75.00 |       15.0         |        410.5          |
@@ -66,7 +66,7 @@ Scenario: An applicant and partner's combined capital is over the lower threshol
       | capital contribution       | 0.0                   |
 
   Scenario: A applicant with a partner with capital and both pensioners
-    Given I am undertaking a standard assessment with a pensioner applicant who is not passported
+    Given I am undertaking a certificated assessment with a pensioner applicant who is not passported
     And I add the following employment details for the partner:
       | client_id |     date     |  gross | benefits_in_kind  | tax   | national_insurance | net_employment_income |
       |     C     |  2022-07-22  | 500.50 |       0           | 75.00 |       15.0         |        410.5          |
@@ -86,7 +86,7 @@ Scenario: An applicant and partner's combined capital is over the lower threshol
       | capital contribution       | 61900.0               |
 
   Scenario: A applicant with housing benefit and a partner with housing costs
-    Given I am undertaking a standard assessment with a pensioner applicant who is not passported
+    Given I am undertaking a certificated assessment with a pensioner applicant who is not passported
     And I add the following housing benefit details for the applicant:
       | client_id |     date     |  amount |
       |     C     |  2022-07-22  | 500.0   |
@@ -102,7 +102,7 @@ Scenario: An applicant and partner's combined capital is over the lower threshol
       | total outgoings and allowances | 291.41   |
 
   Scenario: An applicant with an employed partner who is over the gross income threshold
-    Given I am undertaking a standard assessment with a pensioner applicant who is not passported
+    Given I am undertaking a certificated assessment with a pensioner applicant who is not passported
     And I add the following employment details for the partner:
       | client_id |     date     |  gross | benefits_in_kind  | tax   | national_insurance | net_employment_income |
       |     C     |  2022-07-22  | 5000.50 |       0           | 75.00 |       15.0         |        410.5          |

--- a/features/step_definitions/api_request.rb
+++ b/features/step_definitions/api_request.rb
@@ -1,4 +1,4 @@
-Given("I am undertaking a standard assessment with an applicant who receives passporting benefits") do
+Given("I am undertaking a certificated assessment with an applicant who receives passporting benefits") do
   @api_version = 5
   response = submit_request(:post, "assessments", @api_version,
                             { client_reference_id: "N/A", submission_date: "2022-05-10" })
@@ -12,7 +12,7 @@ Given("I am undertaking a standard assessment with an applicant who receives pas
                  { "proceeding_types": [{ ccms_code: "DA001", client_involvement_type: "A" }] })
 end
 
-Given("I am undertaking a standard assessment with a pensioner applicant who is not passported") do
+Given("I am undertaking a certificated assessment with a pensioner applicant who is not passported") do
   StateBenefitType.create! label: "housing_benefit", name: "Housing benefit", exclude_from_gross_income: true
   @api_version = 5
   response = submit_request(:post, "assessments", @api_version,


### PR DESCRIPTION
Cucumber tests refer to 'standard' checks when they mean 'certificated' - this converts these to use the better terminology