### PR TITLE
EL-638: Ignore LFAPI for upper tribunal matter types

### DIFF
--- a/app/services/legal_framework_api/mock_threshold_waivers.rb
+++ b/app/services/legal_framework_api/mock_threshold_waivers.rb
@@ -36,10 +36,13 @@ module LegalFrameworkAPI
     end
 
     def matter_type(pt_detail)
-      if /^DA/.match?(pt_detail[:ccms_code])
+      case pt_detail[:ccms_code]
+      when /^DA/
         "Domestic abuse"
-      else
+      when /^SE/
         "Children - section 8"
+      else
+        raise "Unrecognised CCMS code: #{pt_detail[:ccms_code]}"
       end
     end
 

--- a/app/services/utilities/proceeding_type_threshold_populator.rb
+++ b/app/services/utilities/proceeding_type_threshold_populator.rb
@@ -59,7 +59,9 @@ module Utilities
     end
 
     def waivers_may_apply?
-      @assessment.level_of_representation == "certificated"
+      @assessment.level_of_representation == "certificated" && @assessment.proceeding_types.none? do |type|
+        type.ccms_code.in?(CFEConstants::IMMIGRATION_AND_ASYLUM_PROCEEDING_TYPE_CCMS_CODES.map(&:to_s))
+      end
     end
   end
 end

--- a/spec/services/legal_framework_api/mock_threshold_waivers_spec.rb
+++ b/spec/services/legal_framework_api/mock_threshold_waivers_spec.rb
@@ -6,15 +6,7 @@ module LegalFrameworkAPI
       allow(SecureRandom).to receive(:uuid).and_return("52fb18ad-257e-4ab1-91da-d7d5e4ff1068")
     end
 
-    describe ".call" do
-      subject(:service) { described_class.call(proceeding_details) }
-
-      it "returns expected response" do
-        expect(service).to eq expected_response
-      end
-    end
-
-    def proceeding_details
+    let(:proceeding_details) do
       [
         {
           ccms_code: "DA004",
@@ -37,6 +29,29 @@ module LegalFrameworkAPI
           client_involvement_type: "Z",
         },
       ]
+    end
+
+    describe ".call" do
+      subject(:service) { described_class.call(proceeding_details) }
+
+      it "returns expected response" do
+        expect(service).to eq expected_response
+      end
+
+      context "when given an unrecognised proceeding type" do
+        let(:proceeding_details) do
+          [
+            {
+              ccms_code: "IM039",
+              client_involvement_type: "A",
+            },
+          ]
+        end
+
+        it "raises an error" do
+          expect { service }.to raise_error "Unrecognised CCMS code: IM039"
+        end
+      end
     end
 
     def expected_response

--- a/spec/services/utilities/proceeding_type_threshold_populator_spec.rb
+++ b/spec/services/utilities/proceeding_type_threshold_populator_spec.rb
@@ -62,7 +62,7 @@ module Utilities
       end
 
       it "updates the threshold values on the proceeding type records where the threshold is not waived" do
-        allow(LegalFrameworkAPI::ThresholdWaivers).to receive(:call).and_return(response)
+        allow(LegalFrameworkAPI::MockThresholdWaivers).to receive(:call).and_return(response)
 
         described_class.call(assessment)
 
@@ -78,7 +78,7 @@ module Utilities
       end
 
       it "updates threshold values on proceeding type records where the threshold is waived" do
-        allow(LegalFrameworkAPI::ThresholdWaivers).to receive(:call).and_return(response)
+        allow(LegalFrameworkAPI::MockThresholdWaivers).to receive(:call).and_return(response)
 
         described_class.call(assessment)
 
@@ -92,11 +92,26 @@ module Utilities
         before { assessment.update(level_of_representation: "controlled") }
 
         it "ignores waivers" do
-          expect(LegalFrameworkAPI::ThresholdWaivers).not_to receive(:call)
+          expect(LegalFrameworkAPI::MockThresholdWaivers).not_to receive(:call)
 
           described_class.call(assessment)
 
           pt = assessment.reload.proceeding_types.find_by(ccms_code: "DA001")
+          expect(pt.gross_income_upper_threshold).to eq 2657.0
+          expect(pt.disposable_income_upper_threshold).to eq 733.0
+          expect(pt.capital_upper_threshold).to eq 8000.0
+        end
+      end
+
+      context "for certificated upper tribunal work" do
+        let(:proceeding_hash) { [%w[IM030 A]] }
+
+        it "ignores waivers" do
+          expect(LegalFrameworkAPI::MockThresholdWaivers).not_to receive(:call)
+
+          described_class.call(assessment)
+
+          pt = assessment.reload.proceeding_types.find_by(ccms_code: "IM030")
           expect(pt.gross_income_upper_threshold).to eq 2657.0
           expect(pt.disposable_income_upper_threshold).to eq 733.0
           expect(pt.capital_upper_threshold).to eq 8000.0


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/EL-638)

We've started sending through certificated assessments with upper tribunal proceeding types, which LFAPI can't handle. So this stops sending these types to LFAPI.