### PR TITLE
Bundler 2.4

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -547,4 +547,4 @@ RUBY VERSION
    ruby 3.2.1p31
 
 BUNDLED WITH
-   2.3.8
+   2.4.7


### PR DESCRIPTION
Upgrade to bundler 2.4.7 (which is the default with ruby 3.2)