### PR TITLE
EL-765 expose pensioner disregard in capital section

### DIFF
--- a/app/lib/person_capital_subtotals.rb
+++ b/app/lib/person_capital_subtotals.rb
@@ -10,6 +10,7 @@ class PersonCapitalSubtotals
     @total_property = data[:total_property]
     @subject_matter_of_dispute_disregard = data[:subject_matter_of_dispute_disregard]
     @pensioner_capital_disregard = data[:pensioner_capital_disregard]
+    @pensioner_disregard_applied = data[:pensioner_disregard_applied]
   end
 
   attr_reader :total_vehicle,
@@ -21,5 +22,6 @@ class PersonCapitalSubtotals
               :total_non_liquid,
               :total_property,
               :subject_matter_of_dispute_disregard,
-              :pensioner_capital_disregard
+              :pensioner_capital_disregard,
+              :pensioner_disregard_applied
 end

--- a/app/services/collators/capital_collator.rb
+++ b/app/services/collators/capital_collator.rb
@@ -45,9 +45,10 @@ module Collators
         total_mortgage_allowance: property_maximum_mortgage_allowance_threshold,
         total_property: property_value,
         pensioner_capital_disregard: @pensioner_capital_disregard,
+        pensioner_disregard_applied: [@pensioner_capital_disregard, total_capital].min,
         subject_matter_of_dispute_disregard: subject_matter_of_dispute_disregard + property_smod,
         total_capital:,
-        assessed_capital:,
+        assessed_capital: [assessed_capital, 0].max,
       )
     end
 

--- a/app/services/decorators/v5/capital_result_decorator.rb
+++ b/app/services/decorators/v5/capital_result_decorator.rb
@@ -10,7 +10,10 @@ module Decorators
 
       def as_json
         if @summary.is_a?(ApplicantCapitalSummary)
-          basic_attributes.merge(proceeding_types:, combined_assessed_capital:, combined_capital_contribution:)
+          basic_attributes.merge(proceeding_types:,
+                                 pensioner_disregard_applied: @person_capital_subtotals.pensioner_disregard_applied.to_f,
+                                 combined_assessed_capital:,
+                                 combined_capital_contribution:)
         else
           basic_attributes
         end

--- a/features/pensioner/pensioner_disregard.feature
+++ b/features/pensioner/pensioner_disregard.feature
@@ -1,0 +1,39 @@
+Feature:
+  "Applicant is a pensioner"
+
+  Scenario: An applicant over 60 with enough disposable income to reduce the pensioner disregard
+    Given I am undertaking a certificated assessment with a pensioner applicant who is not passported
+    And I add the following employment details:
+      | client_id |     date     |  gross  | benefits_in_kind  | tax   | national_insurance | net_employment_income |
+      |     C     |  2022-07-22  | 900.50 |       0           | 75.00 |       15.0         |        410.5          |
+      |     C     |  2022-08-22  | 900.50 |       0           | 75.00 |       15.0         |        410.5          |
+      |     C     |  2022-09-22  | 900.50 |       0           | 75.00 |       15.0         |        410.5          |
+    And I add the following outgoing details for "maintenance_out" in the current assessment:
+      | payment_date | housing_cost_type | client_id | amount  |
+      | 2022-05-10   | rent              | id7       | 550.00  |
+      | 2022-04-10   | rent              | id8       | 550.00  |
+      | 2022-03-10   | rent              | id9       | 550.00  |
+    And I add the following main property details for the current assessment:
+      | value                     | 140000 |
+      | outstanding_mortgage      | 16000  |
+      | percentage_owned          | 100    |
+      | shared_with_housing_assoc | false  |
+    And I add the following capital details for "bank_accounts" for the partner:
+      | description  | value   |
+      | Bank account | 2000.0  |
+    When I retrieve the final assessment
+    Then I should see the following "main property" details:
+      | attribute                  | value    |
+      | value                      | 140000.0 |
+      | main_home_equity_disregard | 100000.0 |
+      | transaction_allowance      | 4200.0   |
+    And I should see the following overall summary:
+      | attribute                    | value    |
+      | assessment_result            | eligible |
+      | capital_lower_threshold      | 3000.0   |
+    And I should see the following "capital summary" details:
+      | attribute                     | value   |
+      | total_capital                 | 19800.0 |
+      | pensioner_capital_disregard  | 20000.0  |
+      | assessed_capital              | 0.0     |
+      | pensioner_disregard_applied   | 19800.0 |

--- a/features/step_definitions/api_request.rb
+++ b/features/step_definitions/api_request.rb
@@ -22,6 +22,7 @@ Given("I am undertaking a certificated assessment with a pensioner applicant who
                  { applicant: { date_of_birth: "1939-12-20",
                                 involvement_type: "applicant",
                                 has_partner_opponent: false,
+                                employed: @employments.present?,
                                 receives_qualifying_benefit: false } })
   submit_request(:post, "assessments/#{@assessment_id}/proceeding_types", @api_version,
                  { "proceeding_types": [{ ccms_code: "SE003", client_involvement_type: "A" }] })
@@ -143,6 +144,12 @@ Given("I add the following employment details for the partner:") do |table|
                             "payments": table.hashes.map { cast_values(_1) } }]
 end
 
+Given("I add the following employment details:") do |table|
+  @employments = [{ "name": "A",
+                    "client_id": "B",
+                    "payments": table.hashes.map { cast_values(_1) } }]
+end
+
 Given("I add the following regular_transaction details for the partner:") do |table|
   @partner_regular_transactions = table.hashes.map { cast_values(_1) }
 end
@@ -179,6 +186,11 @@ When("I retrieve the final assessment") do
     main_home = @main_home || blank_main_home
     data = { "properties": { main_home:, additional_properties: } }
     submit_request(:post, "assessments/#{@assessment_id}/properties", @api_version, data)
+  end
+
+  if @employments
+    data = { employment_income: @employments }
+    submit_request(:post, "assessments/#{@assessment_id}/employments", @api_version, data)
   end
 
   if @partner_employments || @partner_property || @partner_regular_transactions || @partner_capitals

--- a/spec/requests/swagger_docs/v5/full_assessment_spec.rb
+++ b/spec/requests/swagger_docs/v5/full_assessment_spec.rb
@@ -1172,7 +1172,11 @@ RSpec.describe "full_assessment", type: :request, swagger_doc: "v5/swagger.yaml"
                          },
                          subject_matter_of_dispute_disregard: { type: :number },
                          capital_contribution: { type: :number },
-                         assessed_capital: { type: :number },
+                         assessed_capital: {
+                           type: :number,
+                           minimum: 0,
+                           description: "Amount of assessed capital. Zero if deductions exceed total capital."
+                         },
                          combined_assessed_capital: { type: :number },
                          combined_capital_contribution: { type: :number },
                        },

--- a/spec/requests/swagger_docs/v5/full_assessment_spec.rb
+++ b/spec/requests/swagger_docs/v5/full_assessment_spec.rb
@@ -1150,6 +1150,7 @@ RSpec.describe "full_assessment", type: :request, swagger_doc: "v5/swagger.yaml"
                      },
                      capital: {
                        type: :object,
+                       additionalProperties: false,
                        properties: {
                          proceeding_types: {
                            type: :array,
@@ -1161,7 +1162,14 @@ RSpec.describe "full_assessment", type: :request, swagger_doc: "v5/swagger.yaml"
                          total_property: { type: :number },
                          total_mortgage_allowance: { type: :number },
                          total_capital: { type: :number },
-                         pensioner_capital_disregard: { type: :number },
+                         pensioner_capital_disregard: {
+                           type: :number,
+                           description: "Cap on pensioner capital disregard for this assessment (based on disposable_income)",
+                         },
+                         pensioner_disregard_applied: {
+                           type: :number,
+                           description: "Amount of pensioner capital disregard applied to this assessment",
+                         },
                          subject_matter_of_dispute_disregard: { type: :number },
                          capital_contribution: { type: :number },
                          assessed_capital: { type: :number },

--- a/spec/requests/swagger_docs/v5/full_assessment_spec.rb
+++ b/spec/requests/swagger_docs/v5/full_assessment_spec.rb
@@ -1175,7 +1175,7 @@ RSpec.describe "full_assessment", type: :request, swagger_doc: "v5/swagger.yaml"
                          assessed_capital: {
                            type: :number,
                            minimum: 0,
-                           description: "Amount of assessed capital. Zero if deductions exceed total capital."
+                           description: "Amount of assessed capital. Zero if deductions exceed total capital.",
                          },
                          combined_assessed_capital: { type: :number },
                          combined_capital_contribution: { type: :number },

--- a/spec/requests/v2/assessments_controller_spec.rb
+++ b/spec/requests/v2/assessments_controller_spec.rb
@@ -635,6 +635,7 @@ module V2
                 pensioner_capital_disregard: 0.0,
                 subject_matter_of_dispute_disregard: 0.0,
                 assessed_capital: 11_258.99,
+                pensioner_disregard_applied: 0.0,
               })
           end
 

--- a/spec/services/collators/capital_collator_spec.rb
+++ b/spec/services/collators/capital_collator_spec.rb
@@ -35,7 +35,6 @@ module Collators
         it "instantiates and calls the Property Assessment service" do
           property_result = Calculators::PropertyCalculator::Result.new(assessed_equity: 23_000.0, smod_applied: 0)
           allow(Calculators::PropertyCalculator).to receive(:call).and_return([property_result])
-          collator
           expect(collator.total_property).to eq 23_000.0
         end
       end
@@ -43,7 +42,6 @@ module Collators
       context "vehicle assessment" do
         it "instantiates and calls the Vehicle Assesment service" do
           allow(Assessors::VehicleAssessor).to receive(:call).and_return([OpenStruct.new(value: 2_500.0)])
-          collator
           expect(collator.total_vehicle).to eq 2_500.0
         end
       end
@@ -51,7 +49,6 @@ module Collators
       context "non_liquid_capital_assessment" do
         it "instantiates and calls NonLiquidCapitalAssessment" do
           allow(Assessors::NonLiquidCapitalAssessor).to receive(:call).and_return(500)
-          collator
           expect(collator.total_non_liquid).to eq 500.0
         end
       end
@@ -68,8 +65,6 @@ module Collators
           allow(Assessors::NonLiquidCapitalAssessor).to receive(:call).and_return(500)
           allow(Assessors::VehicleAssessor).to receive(:call).and_return([OpenStruct.new(value: 2_500.0)])
 
-          collator
-
           expect(collator.total_liquid).to eq 145.83
           expect(collator.total_non_liquid).to eq 500
           expect(collator.total_vehicle).to eq 2_500
@@ -78,7 +73,8 @@ module Collators
           expect(collator.total_capital).to eq 26_145.83
           expect(collator.pensioner_capital_disregard).to eq 100_000
           expect(collator.subject_matter_of_dispute_disregard).to eq 0
-          expect(collator.assessed_capital).to eq(-73_854.17)
+          expect(collator.assessed_capital).to eq(-0.0)
+          expect(collator.pensioner_disregard_applied).to eq(26_145.83)
         end
       end
     end

--- a/spec/services/decorators/v5/capital_result_decorator_spec.rb
+++ b/spec/services/decorators/v5/capital_result_decorator_spec.rb
@@ -60,6 +60,7 @@ module Decorators
           ],
           combined_assessed_capital: 12_000.0,
           combined_capital_contribution: 0,
+          pensioner_disregard_applied: 0,
         }
       end
 

--- a/swagger/v5/swagger.yaml
+++ b/swagger/v5/swagger.yaml
@@ -863,6 +863,9 @@ paths:
                             type: number
                           assessed_capital:
                             type: number
+                            minimum: 0
+                            description: Amount of assessed capital. Zero if deductions
+                              exceed total capital.
                           combined_assessed_capital:
                             type: number
                           combined_capital_contribution:

--- a/swagger/v5/swagger.yaml
+++ b/swagger/v5/swagger.yaml
@@ -831,6 +831,7 @@ paths:
                             type: object
                       capital:
                         type: object
+                        additionalProperties: false
                         properties:
                           proceeding_types:
                             type: array
@@ -850,6 +851,12 @@ paths:
                             type: number
                           pensioner_capital_disregard:
                             type: number
+                            description: Cap on pensioner capital disregard for this
+                              assessment (based on disposable_income)
+                          pensioner_disregard_applied:
+                            type: number
+                            description: Amount of pensioner capital disregard applied
+                              to this assessment
                           subject_matter_of_dispute_disregard:
                             type: number
                           capital_contribution:


### PR DESCRIPTION
https://dsdmoj.atlassian.net/browse/EL-765

CCQ needs to know how much pensioner capital disregard was applied to the capital calculation so that it can present a sensible set of sums to the user that make sense