### PR TITLE
El 746: Liveness probe checks that the schema is loaded

### DIFF
--- a/app/controllers/status_controller.rb
+++ b/app/controllers/status_controller.rb
@@ -19,7 +19,8 @@ private
 
   def database_alive?
     ActiveRecord::Base.connection.active?
-  rescue PG::ConnectionBad
+    Assessment.count
+  rescue PG::ConnectionBad, PG::UndefinedTable
     false
   end
 end

--- a/app/controllers/status_controller.rb
+++ b/app/controllers/status_controller.rb
@@ -19,7 +19,7 @@ private
 
   def database_alive?
     ActiveRecord::Base.connection.active?
-    Assessment.count
+    Assessment.count.is_a? Numeric
   rescue PG::ConnectionBad, PG::UndefinedTable
     false
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,6 +29,6 @@ Rails.application.routes.draw do
 
   get "ping", to: "status#ping", format: :json
   get "healthcheck", to: "status#status", format: :json
-  get "status", to: "status#ping", format: :json
+  get "status", to: "status#status", format: :json
   get "state_benefit_type", to: "state_benefit_type#index", format: :json
 end

--- a/deploy/helm/templates/deployment_web.yaml
+++ b/deploy/helm/templates/deployment_web.yaml
@@ -30,12 +30,12 @@ spec:
               protocol: TCP
           livenessProbe:
             httpGet:
-              path: /status
+              path: /ping
               port: http
             initialDelaySeconds: 30
           readinessProbe:
             httpGet:
-              path: /status
+              path: /ping
               port: http
             initialDelaySeconds: 30
           resources:

--- a/deploy/helm/templates/deployment_web.yaml
+++ b/deploy/helm/templates/deployment_web.yaml
@@ -30,7 +30,7 @@ spec:
               protocol: TCP
           livenessProbe:
             httpGet:
-              path: /ping
+              path: /status
               port: http
             initialDelaySeconds: 30
           readinessProbe:


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/EL-746)

Describe what you did and why.

- Uncrossed the status paths (/status/ was pointing at the ping method, as was /ping/, while there's a status method that only /healthcheck/ was pointing at) for readability / predictability
- Changed the k8s liveness probe to use the /status/ endpoint, which checks the database
- Added a check to the /status/ endpoint to check that the schema has been loaded