### PR TITLE
EL-710 add undercover to prevent coverage regressions 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,7 +88,7 @@ references:
       name: Install System packages needed for testing
       command: |
         sudo apt-get update
-        sudo apt-get install -y postgresql-client
+        sudo apt-get install -y postgresql-client cmake
   restore_gems_cache: &restore_gems_cache
     restore_cache:
       keys:
@@ -138,13 +138,23 @@ jobs:
           command: |
             curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./tmp/cc-test-reporter
             chmod +x ./tmp/cc-test-reporter
+            ./tmp/cc-test-reporter before-build
       - run:
           name: Run ruby tests
           command: |
-            ./tmp/cc-test-reporter before-build
             bundle exec rspec --format progress --format RspecJunitFormatter -o /tmp/test-results/rspec/rspec.xml
-            ./tmp/cc-test-reporter format-coverage -t simplecov -o tmp/coverage/codeclimate.json
+      - run:
+          name: Format Code Climate Test Coverage
+          command: |
+            ./tmp/cc-test-reporter format-coverage -t lcov -o tmp/coverage/codeclimate.json
+      - run:
+          name: Upload Code Climate Test coverage
+          command: |
             ./tmp/cc-test-reporter upload-coverage -i tmp/coverage/codeclimate.json
+      - run:
+          name: Check coverage with undercover
+          command: |
+            bundle exec undercover -l coverage/lcov.info
       - store_test_results:
           path: /tmp/test-results/rspec
       - store_artifacts:

--- a/Gemfile
+++ b/Gemfile
@@ -78,6 +78,7 @@ group :development, :test do
   gem "rswag-specs"
   gem "rubocop-govuk", require: false
   gem "rubocop-performance"
+  gem "undercover"
 end
 
 group :development do
@@ -95,7 +96,8 @@ group :test do
   gem "cucumber-rails", require: false
   gem "database_cleaner"
   gem "shoulda-matchers"
-  gem "simplecov", require: false
+  gem "simplecov"
+  gem "simplecov-lcov"
   gem "simplecov-rcov"
   gem "super_diff"
   gem "vcr"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -239,6 +239,8 @@ GEM
     httpclient (2.8.3)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
+    imagen (0.1.8)
+      parser (>= 2.5, != 2.5.1.1)
     interception (0.5)
     json (2.6.3)
     json-schema (3.0.0)
@@ -427,6 +429,7 @@ GEM
     ruby-progressbar (1.11.0)
     ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
+    rugged (1.5.1)
     sentry-rails (5.8.0)
       railties (>= 5.0)
       sentry-ruby (~> 5.8.0)
@@ -445,6 +448,7 @@ GEM
       simplecov-html (~> 0.11)
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.12.3)
+    simplecov-lcov (0.8.0)
     simplecov-rcov (0.3.1)
       simplecov (>= 0.4.1)
     simplecov_json_formatter (0.1.4)
@@ -463,6 +467,10 @@ GEM
     tzinfo-data (1.2022.7)
       tzinfo (>= 1.0.0)
     uber (0.1.0)
+    undercover (0.4.5)
+      imagen (>= 0.1.8)
+      rainbow (>= 2.1, < 4.0)
+      rugged (>= 0.27, < 1.6)
     unicode-display_width (2.4.2)
     vcr (6.1.0)
     webmock (3.18.1)
@@ -526,10 +534,12 @@ DEPENDENCIES
   sentry-ruby
   shoulda-matchers
   simplecov
+  simplecov-lcov
   simplecov-rcov
   spring
   super_diff
   tzinfo-data
+  undercover
   vcr
   webmock (>= 3.13.0)
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,23 @@
 require "simplecov"
+require "simplecov-lcov"
 require "vcr"
 
 SimpleCov.minimum_coverage 100 unless ENV["SKIP_COVERAGE"]
+
+# This allows both LCOV and HTML formatting -
+# lcov for undercover gem and cc-test-reporter, HTML for humans
+class SimpleCov::Formatter::MergedFormatter
+  def format(result)
+    SimpleCov::Formatter::HTMLFormatter.new.format(result)
+    SimpleCov::Formatter::LcovFormatter.new.format(result)
+  end
+end
+
+SimpleCov::Formatter::LcovFormatter.config.report_with_single_file = true
+# for cc-test-reporter after-build action
+SimpleCov::Formatter::LcovFormatter.config.output_directory = "coverage"
+SimpleCov::Formatter::LcovFormatter.config.lcov_file_name = "lcov.info"
+SimpleCov.formatter = SimpleCov::Formatter::MergedFormatter
 
 unless ENV["NOCOVERAGE"]
   SimpleCov.start do


### PR DESCRIPTION
https://dsdmoj.atlassian.net/browse/El-710

While branch coverage is incomplete, coverage regressions can take place due to refactorings. This adds the 'undercover' tool to the pipeline to add an extra check, which can be removed if and when we achieve 100% branch coverage