### PR TITLE
Fix "rugged" gem install

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,10 @@ for testing new thresholds before they come into affect on production.
 
     ```sh
     brew install shared-mime-info
+    brew install cmake
     brew install postgresql
+    # run postgres now AND on every boot
+    brew services start postgresql
     ```
 
 3.  Run the setup script:


### PR DESCRIPTION
## What

When running bin/setup to install the gems I hit this error:

```
Installing rugged 1.5.1 with native extensions
Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

    current directory: /Users/david.read/.rbenv/versions/3.2.1/lib/ruby/gems/3.2.0/gems/rugged-1.5.1/ext/rugged
/Users/david.read/.rbenv/versions/3.2.1/bin/ruby -I /Users/david.read/.rbenv/versions/3.2.1/lib/ruby/3.2.0 extconf.rb
checking for gmake... no
checking for make... yes
checking for cmake... no
ERROR: CMake is required to build Rugged.
```

I fixed it by installing cmake, so I've added it to the README.

'rugged' was a introduced yesterday, as a dependency of 'undercover' in #118

Also brew's postgres needs to be started manually on every boot by default, so for convenience I added the command to get it to launch on every boot.

No Jira story


## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
