### PR TITLE
Lep 42 expose allowances for properties

### DIFF
--- a/app/services/utilities/number_utilities.rb
+++ b/app/services/utilities/number_utilities.rb
@@ -1,0 +1,9 @@
+module Utilities
+  class NumberUtilities
+    class << self
+      def negative_to_zero(value)
+        [value, 0.0].max
+      end
+    end
+  end
+end

--- a/features/disputed_assets/disputed_property.feature
+++ b/features/disputed_assets/disputed_property.feature
@@ -1,12 +1,37 @@
 Feature:
     "I have a property that is disputed"
 
+    Scenario: A SMOD property where equity is less than transaction_allowance
+      Given I am undertaking a certificated assessment with an applicant who receives passporting benefits
+      And I am using version 5 of the API
+      And I add the following main property details for the current assessment:
+        | value                     | 150000 |
+        | outstanding_mortgage      | 147000 |
+        | percentage_owned          | 100    |
+        | shared_with_housing_assoc | false  |
+        | subject_matter_of_dispute | true   |
+      When I retrieve the final assessment
+      Then I should see the following "main property" details:
+        | attribute                  | value    |
+        | value                      | 150000.0 |
+        | transaction_allowance      |   3000.0 |
+        | net_value                  |      0.0 |
+        | net_equity                 |      0.0 |
+        | main_home_equity_disregard |      0.0 |
+        | assessed_equity            |      0.0 |
+        | smod_allowance             |      0.0 |
+      And I should see the following "capital summary" details:
+        | attribute                           | value   |
+        | total_property                      |     0.0 |
+        | subject_matter_of_dispute_disregard |     0.0 |
+        | assessed_capital                    |     0.0 |
+
     Scenario: A SMOD property where the value of the client's share of its equity is entirely disregarded
         Given I am undertaking a certificated assessment with an applicant who receives passporting benefits
         And I am using version 5 of the API
         And I add the following main property details for the current assessment:
             | value                     | 150000 |
-            | outstanding_mortgage      | 0      |
+            | outstanding_mortgage      | 146000 |
             | percentage_owned          | 100    |
             | shared_with_housing_assoc | false  |
             | subject_matter_of_dispute | true   |
@@ -14,14 +39,14 @@ Feature:
         Then I should see the following "main property" details:
             | attribute                  | value    |
             | value                      | 150000.0 |
-            | main_home_equity_disregard | 100000.0 |
-            | transaction_allowance      | 4500.0   |
-            | assessed_equity            | 0.0      |
+            | main_home_equity_disregard |      0.0 |
+            | transaction_allowance      |   4000.0 |
+            | assessed_equity            |      0.0 |
         And I should see the following "capital summary" details:
-            | attribute                           | value    |
-            | total_property                      | 0.0      |
-            | subject_matter_of_dispute_disregard | 100000.0 |
-            | assessed_capital                    | 0.0      |
+            | attribute                           | value  |
+            | total_property                      | 0.0    |
+            | subject_matter_of_dispute_disregard | 0.0    |
+            | assessed_capital                    | 0.0    |
 
     Scenario: The SMOD disregard is capped if the property is assessed as being worth more than £100k.
         Given I am undertaking a certificated assessment with an applicant who receives passporting benefits

--- a/features/disputed_assets/multiple_disputed_assets.feature
+++ b/features/disputed_assets/multiple_disputed_assets.feature
@@ -23,7 +23,7 @@ Feature:
     Then I should see the following "main property" details:
       | attribute                  | value    |
       | value                      | 150000.0 |
-      | main_home_equity_disregard | 100000.0 |
+      | main_home_equity_disregard | 45500.0 |
       | transaction_allowance      | 4500.0   |
       | assessed_equity            | 0.0      |
     And I should see the following "capital summary" details:

--- a/features/partner/partner_assessment.feature
+++ b/features/partner/partner_assessment.feature
@@ -20,7 +20,7 @@ Feature:
     Then I should see the following "main property" details:
       | attribute                  | value    |
       | value                      | 150000.0 |
-      | main_home_equity_disregard | 100000.0 |
+      | main_home_equity_disregard | 500.0    |
       | transaction_allowance      | 4500.0   |
       | assessed_equity            | 0.0      |
     And I should see the following "partner property" details for the partner:

--- a/features/property/property.feature
+++ b/features/property/property.feature
@@ -1,0 +1,25 @@
+Feature:
+  "I have a property"
+
+  Scenario: A property where the main home equity is smaller than the capped disregard figure
+    Given I am undertaking a certificated assessment with an applicant who receives passporting benefits
+    And I am using version 5 of the API
+    And I add the following main property details for the current assessment:
+      | value                      | 150000 |
+      | outstanding_mortgage       | 100000 |
+      | percentage_owned           |     50 |
+      | shared_with_housing_assoc  | false  |
+      | subject_matter_of_dispute  | false  |
+    When I retrieve the final assessment
+    Then I should see the following "main property" details:
+      | attribute                  | value    |
+      | value                      | 150000.0 |
+      | transaction_allowance      |   4500.0 |
+      | net_value                  |  45500.0 |
+      | net_equity                 |  22750.0 |
+      | main_home_equity_disregard |  22750.0 |
+      | assessed_equity            |      0.0 |
+    And I should see the following "capital summary" details:
+      | attribute                  | value    |
+      | total_property             |      0.0 |
+      | assessed_capital           |      0.0 |

--- a/spec/integration/v5_full_assessment_spec.rb
+++ b/spec/integration/v5_full_assessment_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe "Full V5 passported spec", :vcr do
             allowable_outstanding_mortgage: 999.99,
             net_value: 484_000.02,
             net_equity: 59_000.01,
-            main_home_equity_disregard: 100_000.0,
+            main_home_equity_disregard: 59_000.01,
             assessed_equity: 0.0,
             smod_allowance: 0.0,
             transaction_allowance: 15_000.0,

--- a/spec/requests/v2/assessments_controller_spec.rb
+++ b/spec/requests/v2/assessments_controller_spec.rb
@@ -300,14 +300,14 @@ module V2
 
           it "has liquid" do
             expect(capital_items.fetch(:liquid))
-              .to eq(
+              .to match_array(
                 [{ description: bank_1, value: 28.34 }, { description: bank_2, value: 67.23 }],
               )
           end
 
           it "has non_liquid" do
             expect(capital_items.fetch(:non_liquid))
-              .to eq(
+              .to match_array(
                 [{ description: "R.J.Ewing Trust", value: 17.12 }, { description: "Ming Vase", value: 6.19 }],
               )
           end
@@ -913,7 +913,7 @@ module V2
                     allowable_outstanding_mortgage: 200.0,
                     net_value: 484_800.0,
                     net_equity: 59_800.0,
-                    main_home_equity_disregard: 100_000.0,
+                    main_home_equity_disregard: 59_800.0,
                     assessed_equity: 0.0,
                     smod_allowance: 0.0,
                   })

--- a/spec/services/calculators/property_calculator_spec.rb
+++ b/spec/services/calculators/property_calculator_spec.rb
@@ -193,7 +193,7 @@ module Calculators
                 { transaction_allowance: 4_800.0, # 3% of 160,000
                   net_value: 85_200.0, # 160,000 - 4,800 - 70,000
                   net_equity: 5_200.0, # 85,200.0 - (50% of 160,000)
-                  main_home_equity_disregard: 100_000.0,
+                  main_home_equity_disregard: 5_200.0,
                   assessed_equity: 0 },
               )
           end

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -109,6 +109,7 @@ RSpec.configure do |config|
               },
               main_home_equity_disregard: {
                 type: :number,
+                description: "Amount of main home equity disregard applied to this property",
               },
               assessed_equity: {
                 type: :number,

--- a/swagger/v5/swagger.yaml
+++ b/swagger/v5/swagger.yaml
@@ -129,6 +129,7 @@ components:
           maximum: 100000.0
         main_home_equity_disregard:
           type: number
+          description: Amount of main home equity disregard applied to this property
         assessed_equity:
           type: number
           minimum: 0.0


### PR DESCRIPTION
https://dsdmoj.atlassian.net/browse/LEP-42

This makes 2 subtle changes to the semantics of the 'property' fields, which are not thought to be breaking changes:
a) main_property_equity_disregard was always set to 100_000 - this is now the actual main disregard in use
b) transaction_allowance was always 3% of property value - it is now less than that (but non-zero) if the equity is less than the transaction allowance
