### PR TITLE
Update cloud-platform-tools image to fix circle deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ executors:
       - image: cimg/base:2020.01
   cloud-platform-executor:
     docker:
-      - image: ministryofjustice/cloud-platform-tools:2.1
+      - image: ministryofjustice/cloud-platform-tools:2.3.0
         environment:
           GITHUB_TEAM_NAME_SLUG: laa-estimate-eligibility
   linting-executor:
@@ -68,7 +68,7 @@ references:
         sudo apt-get update
         sudo apt-get install -y python3-pip
         sudo pip3 install awscli
-        $(aws ecr get-login --region eu-west-2 --no-include-email)
+        aws ecr get-login-password --region eu-west-2 | docker login --username AWS --password-stdin ${ECR_ENDPOINT}
   authenticate_k8s: &authenticate_k8s
     run:
       name: Authenticate with cluster


### PR DESCRIPTION
## What

This is an update of cloud-platform-tool image to the latest, 2.3.0. I believe this updates to aws cli v2, hence the ECR login update.

This PR is a copy of the fix here: https://github.com/ministryofjustice/check-financial-eligibility/pull/1348/files

**Cause**

Colin said:
> Github updated their SSH key at 05:00UTC this morning… https://github.blog/2023-03-23-we-updated-our-rsa-ssh-host-key
> This has broken some of our circle deploys as the executor we use seems to have cached the old version

(No Jira ticket)

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
