### PR TITLE
LEP-22 Stop persisting employment values in disposable_income_summary

### DIFF
--- a/app/lib/employment_income_subtotals.rb
+++ b/app/lib/employment_income_subtotals.rb
@@ -14,4 +14,8 @@ class EmploymentIncomeSubtotals
               :fixed_employment_allowance,
               :tax,
               :national_insurance
+
+  def net_employment_income
+    gross_employment_income + employment_income_deductions + fixed_employment_allowance
+  end
 end

--- a/app/services/collators/disposable_income_collator.rb
+++ b/app/services/collators/disposable_income_collator.rb
@@ -3,16 +3,16 @@ module Collators
     Attrs = Data.define(:attrs, :monthly_cash_transactions_total)
 
     class << self
-      def call(disposable_income_summary:, gross_income_summary:, partner_allowance:, total_gross_income:)
-        new(gross_income_summary:, disposable_income_summary:, partner_allowance:, total_gross_income:).call
+      def call(disposable_income_summary:, gross_income_summary:, partner_allowance:, gross_income_subtotals:)
+        new(gross_income_summary:, disposable_income_summary:, partner_allowance:, gross_income_subtotals:).call
       end
     end
 
-    def initialize(disposable_income_summary:, gross_income_summary:, partner_allowance:, total_gross_income:)
+    def initialize(disposable_income_summary:, gross_income_summary:, partner_allowance:, gross_income_subtotals:)
       @disposable_income_summary = disposable_income_summary
       @gross_income_summary = gross_income_summary
       @partner_allowance = partner_allowance
-      @total_gross_income = total_gross_income
+      @gross_income_subtotals = gross_income_subtotals
     end
 
     def call
@@ -61,8 +61,8 @@ module Collators
         @disposable_income_summary.dependant_allowance +
         monthly_bank_transactions_total +
         monthly_cash_transactions_total -
-        @disposable_income_summary.fixed_employment_allowance -
-        @disposable_income_summary.employment_income_deductions +
+        @gross_income_subtotals.employment_income_subtotals.fixed_employment_allowance -
+        @gross_income_subtotals.employment_income_subtotals.employment_income_deductions +
         @partner_allowance
     end
 
@@ -73,7 +73,7 @@ module Collators
     end
 
     def disposable_income(monthly_cash_transactions_total)
-      @total_gross_income - total_outgoings_and_allowances(monthly_cash_transactions_total)
+      @gross_income_subtotals.total_gross_income - total_outgoings_and_allowances(monthly_cash_transactions_total)
     end
   end
 end

--- a/app/services/decorators/v5/disposable_income_result_decorator.rb
+++ b/app/services/decorators/v5/disposable_income_result_decorator.rb
@@ -37,18 +37,14 @@ module Decorators
 
       attr_reader :summary, :gross_income_summary
 
-      def net_employment_income
-        @employment_income_subtotals.gross_employment_income + summary.employment_income_deductions + summary.fixed_employment_allowance
-      end
-
       def employment_income
         {
           gross_income: @employment_income_subtotals.gross_employment_income.to_f,
           benefits_in_kind: @employment_income_subtotals.benefits_in_kind.to_f,
-          tax: summary.tax.to_f,
-          national_insurance: summary.national_insurance.to_f,
-          fixed_employment_deduction: summary.fixed_employment_allowance.to_f,
-          net_employment_income: net_employment_income.to_f,
+          tax: @employment_income_subtotals.tax.to_f,
+          national_insurance: @employment_income_subtotals.national_insurance.to_f,
+          fixed_employment_deduction: @employment_income_subtotals.fixed_employment_allowance.to_f,
+          net_employment_income: @employment_income_subtotals.net_employment_income.to_f,
         }
       end
 

--- a/app/services/workflows/non_passported_workflow.rb
+++ b/app/services/workflows/non_passported_workflow.rb
@@ -76,11 +76,11 @@ module Workflows
         Collators::DisposableIncomeCollator.call(gross_income_summary: assessment.gross_income_summary.freeze,
                                                  disposable_income_summary: assessment.disposable_income_summary,
                                                  partner_allowance:,
-                                                 total_gross_income: gross_income_subtotals.applicant_gross_income_subtotals.total_gross_income)
+                                                 gross_income_subtotals: gross_income_subtotals.applicant_gross_income_subtotals)
         Collators::DisposableIncomeCollator.call(gross_income_summary: assessment.partner_gross_income_summary.freeze,
                                                  disposable_income_summary: assessment.partner_disposable_income_summary,
                                                  partner_allowance: 0,
-                                                 total_gross_income: gross_income_subtotals.partner_gross_income_subtotals.total_gross_income)
+                                                 gross_income_subtotals: gross_income_subtotals.partner_gross_income_subtotals)
 
         Collators::RegularOutgoingsCollator.call(gross_income_summary: assessment.gross_income_summary.freeze,
                                                  disposable_income_summary: assessment.disposable_income_summary,
@@ -108,7 +108,7 @@ module Workflows
         Collators::DisposableIncomeCollator.call(gross_income_summary: assessment.gross_income_summary.freeze,
                                                  disposable_income_summary: assessment.disposable_income_summary,
                                                  partner_allowance: 0,
-                                                 total_gross_income: gross_income_subtotals.applicant_gross_income_subtotals.total_gross_income)
+                                                 gross_income_subtotals: gross_income_subtotals.applicant_gross_income_subtotals)
         Collators::RegularOutgoingsCollator.call(gross_income_summary: assessment.gross_income_summary.freeze,
                                                  disposable_income_summary: assessment.disposable_income_summary,
                                                  eligible_for_childcare:)

--- a/db/migrate/20230324150833_remove_employment_from_disposable_income.rb
+++ b/db/migrate/20230324150833_remove_employment_from_disposable_income.rb
@@ -1,0 +1,11 @@
+class RemoveEmploymentFromDisposableIncome < ActiveRecord::Migration[7.0]
+  def change
+    change_table :disposable_income_summaries, bulk: true do |t|
+      t.remove :employment_income_deductions,
+               :fixed_employment_allowance,
+               :tax,
+               :national_insurance,
+               type: :decimal, default: 0, null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_02_25_142836) do
+ActiveRecord::Schema[7.0].define(version: 2023_03_24_150833) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -134,10 +134,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_25_142836) do
     t.decimal "maintenance_out_cash", default: "0.0"
     t.decimal "rent_or_mortgage_cash", default: "0.0"
     t.decimal "legal_aid_cash", default: "0.0"
-    t.decimal "employment_income_deductions", default: "0.0", null: false
-    t.decimal "fixed_employment_allowance", default: "0.0", null: false
-    t.decimal "tax", default: "0.0", null: false
-    t.decimal "national_insurance", default: "0.0", null: false
     t.string "type", default: "ApplicantDisposableIncomeSummary"
     t.decimal "combined_total_disposable_income"
     t.decimal "combined_total_outgoings_and_allowances"

--- a/spec/services/collators/disposable_income_collator_spec.rb
+++ b/spec/services/collators/disposable_income_collator_spec.rb
@@ -14,6 +14,12 @@ module Collators
     let(:dependant_allowance) { 582.98 }
     let(:partner_allowance) { 481.29 }
     let(:total_gross_income) { 0 }
+    let(:gross_income_subtotals) do
+      PersonGrossIncomeSubtotals.new(
+        total_gross_income:,
+        employment_income_subtotals: EmploymentIncomeSubtotals.new(employment_income_deductions:, fixed_employment_allowance:),
+      )
+    end
 
     let(:disposable_income_summary) do
       summary = create(:disposable_income_summary,
@@ -26,9 +32,7 @@ module Collators
                        net_housing_costs: net_housing,
                        total_outgoings_and_allowances: 0.0,
                        dependant_allowance:,
-                       total_disposable_income: 0.0,
-                       employment_income_deductions:,
-                       fixed_employment_allowance:)
+                       total_disposable_income: 0.0)
       create :disposable_income_eligibility, disposable_income_summary: summary, proceeding_type_code: "DA001"
       summary
     end
@@ -54,7 +58,7 @@ module Collators
         described_class.call(gross_income_summary: assessment.gross_income_summary,
                              disposable_income_summary: assessment.disposable_income_summary,
                              partner_allowance:,
-                             total_gross_income:)
+                             gross_income_subtotals:)
       end
 
       context "total_monthly_outgoings" do

--- a/spec/services/collators/gross_income_collator_spec.rb
+++ b/spec/services/collators/gross_income_collator_spec.rb
@@ -152,17 +152,14 @@ module Collators
           let(:disposable_income_summary) { assessment.disposable_income_summary }
 
           it "has a total gross employed income" do
-            response = collator
-            expect(response.employment_income_subtotals.gross_employment_income).to eq 1500
+            expect(collator.employment_income_subtotals.gross_employment_income).to eq 1500
           end
 
-          it "updates disposable income summary" do
-            collator
-            disposable_income_summary.reload
-            expect(disposable_income_summary.employment_income_deductions).to eq(-645)
-            expect(disposable_income_summary.tax).to eq(-495)
-            expect(disposable_income_summary.national_insurance).to eq(-150)
-            expect(disposable_income_summary.fixed_employment_allowance).to eq(-45)
+          it "returns employment_income_subtotals" do
+            expect(collator.employment_income_subtotals.employment_income_deductions).to eq(-645)
+            expect(collator.employment_income_subtotals.tax).to eq(-495)
+            expect(collator.employment_income_subtotals.national_insurance).to eq(-150)
+            expect(collator.employment_income_subtotals.fixed_employment_allowance).to eq(-45)
           end
         end
       end

--- a/spec/services/decorators/v5/disposable_income_result_decorator_spec.rb
+++ b/spec/services/decorators/v5/disposable_income_result_decorator_spec.rb
@@ -87,7 +87,7 @@ module Decorators
         }
       end
 
-      let(:employment_income_subtotals) { EmploymentIncomeSubtotals.new(gross_employment_income: 0, benefits_in_kind: 0) }
+      let(:employment_income_subtotals) { EmploymentIncomeSubtotals.new }
 
       subject(:decorator) { described_class.new(summary, assessment.gross_income_summary, employment_income_subtotals, partner_present:).as_json }
 
@@ -105,16 +105,17 @@ module Decorators
       end
 
       describe "#as_json" do
-        it "returns the expected structure" do
+        before do
           employment1
           employment2
-          result = Calculators::MultipleEmploymentsCalculator.call(assessment:,
-                                                                   employments: assessment.employments)
-          assessment.disposable_income_summary.update!(employment_income_deductions: result.employment_income_deductions,
-                                                       fixed_employment_allowance: result.fixed_employment_allowance,
-                                                       tax: result.tax,
-                                                       national_insurance: result.national_insurance)
+        end
 
+        let(:employment_income_subtotals) do
+          Calculators::MultipleEmploymentsCalculator.call(assessment:,
+                                                          employments: assessment.employments)
+        end
+
+        it "returns the expected structure" do
           expect(decorator).to eq expected_result
         end
       end


### PR DESCRIPTION
https://dsdmoj.atlassian.net/browse/LEP-22

As part of LEP-22/EL-688, remove employment summary figures from disposable income summary. These figures were already returned and passed to the decorator display layer
