### PR TITLE
LEP-22 Remove dependant allowance from disposable_income_summary

### DIFF
--- a/app/lib/calculation_output.rb
+++ b/app/lib/calculation_output.rb
@@ -1,7 +1,10 @@
 class CalculationOutput
-  def initialize(gross_income_subtotals: nil, capital_subtotals: nil)
+  delegate :dependant_allowance, :partner_dependant_allowance, to: :@disposable_income_subtotals
+
+  def initialize(gross_income_subtotals: nil, capital_subtotals: nil, disposable_income_subtotals: nil)
     @capital_subtotals = capital_subtotals || CapitalSubtotals.new
     @gross_income_subtotals = gross_income_subtotals || GrossIncomeSubtotals.new
+    @disposable_income_subtotals = disposable_income_subtotals || DisposableIncomeSubtotals.new
   end
 
   attr_reader :capital_subtotals, :gross_income_subtotals

--- a/app/lib/disposable_income_subtotals.rb
+++ b/app/lib/disposable_income_subtotals.rb
@@ -1,0 +1,8 @@
+class DisposableIncomeSubtotals
+  attr_reader :dependant_allowance, :partner_dependant_allowance
+
+  def initialize(dependant_allowance: 0, partner_dependant_allowance: 0)
+    @dependant_allowance = dependant_allowance
+    @partner_dependant_allowance = partner_dependant_allowance
+  end
+end

--- a/app/services/collators/disposable_income_collator.rb
+++ b/app/services/collators/disposable_income_collator.rb
@@ -3,16 +3,17 @@ module Collators
     Attrs = Data.define(:attrs, :monthly_cash_transactions_total)
 
     class << self
-      def call(disposable_income_summary:, gross_income_summary:, partner_allowance:, gross_income_subtotals:)
-        new(gross_income_summary:, disposable_income_summary:, partner_allowance:, gross_income_subtotals:).call
+      def call(disposable_income_summary:, gross_income_summary:, partner_allowance:, gross_income_subtotals:, outgoings:)
+        new(gross_income_summary:, disposable_income_summary:, partner_allowance:, gross_income_subtotals:, outgoings:).call
       end
     end
 
-    def initialize(disposable_income_summary:, gross_income_summary:, partner_allowance:, gross_income_subtotals:)
+    def initialize(disposable_income_summary:, gross_income_summary:, partner_allowance:, gross_income_subtotals:, outgoings:)
       @disposable_income_summary = disposable_income_summary
       @gross_income_summary = gross_income_summary
       @partner_allowance = partner_allowance
       @gross_income_subtotals = gross_income_subtotals
+      @outgoings = outgoings
     end
 
     def call
@@ -58,7 +59,7 @@ module Collators
 
     def total_outgoings_and_allowances(monthly_cash_transactions_total)
       @disposable_income_summary.net_housing_costs +
-        @disposable_income_summary.dependant_allowance +
+        @outgoings.dependant_allowance +
         monthly_bank_transactions_total +
         monthly_cash_transactions_total -
         @gross_income_subtotals.employment_income_subtotals.fixed_employment_allowance -

--- a/app/services/collators/outgoings_collator.rb
+++ b/app/services/collators/outgoings_collator.rb
@@ -1,5 +1,7 @@
 module Collators
   class OutgoingsCollator
+    Result = Data.define(:dependant_allowance)
+
     class << self
       def call(submission_date:, person:, gross_income_summary:, disposable_income_summary:, eligible_for_childcare:, allow_negative_net:)
         # sets child_care_bank and child_care_cash fields in disposable_income_summary
@@ -11,10 +13,8 @@ module Collators
         disposable_income_summary.update!(child_care_bank: child_care.bank, child_care_cash: child_care.cash)
 
         # sets dependant_allowance on each dependant,
-        # and dependant_allowance on disposable_income_summary as the sum of them
         dependent_allowance = Collators::DependantsAllowanceCollator.call(dependants: person.dependants,
                                                                           submission_date:)
-        disposable_income_summary.update!(dependant_allowance: dependent_allowance)
 
         # sets maintenance_out_bank on disposable_income_summary
         maintenance_out_bank = Collators::MaintenanceCollator.call(disposable_income_summary)
@@ -35,6 +35,8 @@ module Collators
         legal_aid_bank = Collators::LegalAidCollator.call(disposable_income_summary)
         # TODO: return this instead of persisting it
         disposable_income_summary.update!(legal_aid_bank:)
+
+        Result.new(dependant_allowance: dependent_allowance)
       end
     end
   end

--- a/app/services/decorators/v5/assessment_decorator.rb
+++ b/app/services/decorators/v5/assessment_decorator.rb
@@ -32,7 +32,7 @@ module Decorators
           level_of_help: assessment.level_of_help,
           applicant: ApplicantDecorator.new(assessment.applicant),
           gross_income:,
-          disposable_income: DisposableIncomeDecorator.new(assessment.disposable_income_summary),
+          disposable_income: DisposableIncomeDecorator.new(assessment.disposable_income_summary, @calculation_output.dependant_allowance),
           capital: CapitalDecorator.new(assessment.capital_summary,
                                         @calculation_output.capital_subtotals.applicant_capital_subtotals),
           remarks: RemarksDecorator.new(assessment.remarks, assessment),
@@ -57,7 +57,7 @@ module Decorators
       end
 
       def partner_disposable_income
-        DisposableIncomeDecorator.new(assessment.partner_disposable_income_summary)
+        DisposableIncomeDecorator.new(assessment.partner_disposable_income_summary, @calculation_output.partner_dependant_allowance)
       end
 
       def partner_capital

--- a/app/services/decorators/v5/deductions_decorator.rb
+++ b/app/services/decorators/v5/deductions_decorator.rb
@@ -1,13 +1,14 @@
 module Decorators
   module V5
     class DeductionsDecorator
-      def initialize(disposable_income_summary)
+      def initialize(disposable_income_summary, dependant_allowance:)
         @record = disposable_income_summary
+        @dependant_allowance = dependant_allowance
       end
 
       def as_json
         {
-          dependants_allowance: @record.dependant_allowance,
+          dependants_allowance: @dependant_allowance,
           disregarded_state_benefits: Calculators::DisregardedStateBenefitsCalculator.call(@record),
         }
       end

--- a/app/services/decorators/v5/disposable_income_decorator.rb
+++ b/app/services/decorators/v5/disposable_income_decorator.rb
@@ -3,8 +3,9 @@ module Decorators
     class DisposableIncomeDecorator
       attr_reader :record, :categories
 
-      def initialize(summary)
+      def initialize(summary, dependant_allowance)
         @summary = summary
+        @dependant_allowance = dependant_allowance
         @categories = CFEConstants::VALID_OUTGOING_CATEGORIES.map(&:to_sym)
       end
 
@@ -41,7 +42,7 @@ module Decorators
 
       def deductions
         {
-          dependants_allowance: @summary.dependant_allowance.to_f,
+          dependants_allowance: @dependant_allowance.to_f,
           disregarded_state_benefits: Calculators::DisregardedStateBenefitsCalculator.call(@summary).to_f,
         }
       end

--- a/app/services/decorators/v5/disposable_income_result_decorator.rb
+++ b/app/services/decorators/v5/disposable_income_result_decorator.rb
@@ -1,15 +1,16 @@
 module Decorators
   module V5
     class DisposableIncomeResultDecorator
-      def initialize(summary, gross_income_summary, employment_income_subtotals, partner_present:)
+      def initialize(summary, gross_income_summary, employment_income_subtotals, partner_present:, dependant_allowance:)
         @summary = summary
         @gross_income_summary = gross_income_summary
         @employment_income_subtotals = employment_income_subtotals
         @partner_present = partner_present
+        @dependant_allowance = dependant_allowance
       end
 
       def as_json
-        if summary.is_a?(ApplicantDisposableIncomeSummary)
+        if @summary.is_a?(ApplicantDisposableIncomeSummary)
           basic_attributes.merge(proceeding_types:,
                                  combined_total_disposable_income:,
                                  combined_total_outgoings_and_allowances:,
@@ -21,21 +22,19 @@ module Decorators
 
       def basic_attributes
         {
-          dependant_allowance: summary.dependant_allowance.to_f,
-          gross_housing_costs: summary.gross_housing_costs.to_f,
-          housing_benefit: summary.housing_benefit.to_f,
-          net_housing_costs: summary.net_housing_costs.to_f,
-          maintenance_allowance: summary.maintenance_out_all_sources.to_f,
-          total_outgoings_and_allowances: summary.total_outgoings_and_allowances.to_f,
-          total_disposable_income: summary.total_disposable_income.to_f,
+          dependant_allowance: @dependant_allowance.to_f,
+          gross_housing_costs: @summary.gross_housing_costs.to_f,
+          housing_benefit: @summary.housing_benefit.to_f,
+          net_housing_costs: @summary.net_housing_costs.to_f,
+          maintenance_allowance: @summary.maintenance_out_all_sources.to_f,
+          total_outgoings_and_allowances: @summary.total_outgoings_and_allowances.to_f,
+          total_disposable_income: @summary.total_disposable_income.to_f,
           employment_income:,
-          income_contribution: summary.income_contribution.to_f,
+          income_contribution: @summary.income_contribution.to_f,
         }
       end
 
     private
-
-      attr_reader :summary, :gross_income_summary
 
       def employment_income
         {
@@ -49,7 +48,7 @@ module Decorators
       end
 
       def proceeding_types
-        ProceedingTypesResultDecorator.new(summary.eligibilities, summary.assessment.proceeding_types).as_json
+        ProceedingTypesResultDecorator.new(@summary.eligibilities, @summary.assessment.proceeding_types).as_json
       end
 
       def partner_allowance
@@ -59,11 +58,11 @@ module Decorators
       end
 
       def combined_total_disposable_income
-        summary.combined_total_disposable_income.to_f
+        @summary.combined_total_disposable_income.to_f
       end
 
       def combined_total_outgoings_and_allowances
-        summary.combined_total_outgoings_and_allowances.to_f
+        @summary.combined_total_outgoings_and_allowances.to_f
       end
     end
   end

--- a/app/services/decorators/v5/result_summary_decorator.rb
+++ b/app/services/decorators/v5/result_summary_decorator.rb
@@ -27,7 +27,8 @@ module Decorators
           disposable_income: DisposableIncomeResultDecorator.new(disposable_income_summary,
                                                                  gross_income_summary,
                                                                  @calculation_output.gross_income_subtotals.applicant_gross_income_subtotals.employment_income_subtotals,
-                                                                 partner_present: assessment.partner.present?).as_json,
+                                                                 partner_present: assessment.partner.present?,
+                                                                 dependant_allowance: @calculation_output.dependant_allowance).as_json,
           capital: CapitalResultDecorator.new(capital_summary,
                                               @calculation_output.capital_subtotals.applicant_capital_subtotals,
                                               @calculation_output.capital_subtotals.capital_contribution.to_f,
@@ -50,7 +51,8 @@ module Decorators
         DisposableIncomeResultDecorator.new(assessment.partner_disposable_income_summary,
                                             assessment.partner_gross_income_summary,
                                             @calculation_output.gross_income_subtotals.partner_gross_income_subtotals.employment_income_subtotals,
-                                            partner_present: true).as_json
+                                            partner_present: true,
+                                            dependant_allowance: @calculation_output.partner_dependant_allowance).as_json
       end
 
       def partner_capital

--- a/db/migrate/20230327082347_remove_dependant_allowance.rb
+++ b/db/migrate/20230327082347_remove_dependant_allowance.rb
@@ -1,0 +1,8 @@
+class RemoveDependantAllowance < ActiveRecord::Migration[7.0]
+  def change
+    change_table :disposable_income_summaries, bulk: true do |t|
+      t.remove :dependant_allowance,
+               type: :decimal, default: 0, null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_03_24_150833) do
+ActiveRecord::Schema[7.0].define(version: 2023_03_27_082347) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -110,7 +110,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_24_150833) do
 
   create_table "disposable_income_summaries", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "assessment_id", null: false
-    t.decimal "dependant_allowance", default: "0.0", null: false
     t.decimal "gross_housing_costs", default: "0.0", null: false
     t.decimal "total_outgoings_and_allowances", default: "0.0", null: false
     t.decimal "total_disposable_income", default: "0.0", null: false

--- a/spec/factories/disposable_income_summary_factory.rb
+++ b/spec/factories/disposable_income_summary_factory.rb
@@ -4,7 +4,6 @@ FactoryBot.define do
     child_care_bank { 0.0 }
     maintenance_out_bank { 0.0 }
     legal_aid_bank { 0.0 }
-    dependant_allowance { 0.0 }
     gross_housing_costs { 0.0 }
     rent_or_mortgage_bank { 0.0 }
     net_housing_costs { 0.0 }

--- a/spec/services/collators/disposable_income_collator_spec.rb
+++ b/spec/services/collators/disposable_income_collator_spec.rb
@@ -31,7 +31,6 @@ module Collators
                        housing_benefit:,
                        net_housing_costs: net_housing,
                        total_outgoings_and_allowances: 0.0,
-                       dependant_allowance:,
                        total_disposable_income: 0.0)
       create :disposable_income_eligibility, disposable_income_summary: summary, proceeding_type_code: "DA001"
       summary
@@ -58,7 +57,8 @@ module Collators
         described_class.call(gross_income_summary: assessment.gross_income_summary,
                              disposable_income_summary: assessment.disposable_income_summary,
                              partner_allowance:,
-                             gross_income_subtotals:)
+                             gross_income_subtotals:,
+                             outgoings: OutgoingsCollator::Result.new(dependant_allowance:))
       end
 
       context "total_monthly_outgoings" do

--- a/spec/services/decorators/v5/deductions_decorator_spec.rb
+++ b/spec/services/decorators/v5/deductions_decorator_spec.rb
@@ -4,9 +4,9 @@ module Decorators
   module V5
     RSpec.describe DeductionsDecorator do
       describe "#as_json" do
-        subject(:decorator) { described_class.new(record).as_json }
+        subject(:decorator) { described_class.new(record, dependant_allowance: 1283.66).as_json }
 
-        let(:record) { create :disposable_income_summary, dependant_allowance: 1283.66 }
+        let(:record) { create :disposable_income_summary }
 
         it "returns expected hash" do
           allow(Calculators::DisregardedStateBenefitsCalculator).to receive(:call).with(record).and_return(587.00)


### PR DESCRIPTION
https://dsdmoj.atlassian.net/browse/LEP-22

Following on from removing employment fields, this removes the dependant allowance and passes it along the chain in the output