### PR TITLE
LEP-81 Add outgoings to partner financials endpoint

### DIFF
--- a/app/controllers/outgoings_controller.rb
+++ b/app/controllers/outgoings_controller.rb
@@ -14,7 +14,7 @@ private
   def outgoing_creation_service
     @outgoing_creation_service ||= Creators::OutgoingsCreator.call(
       outgoings_params:,
-      assessment: @assessment,
+      disposable_income_summary: @assessment.disposable_income_summary,
     )
   end
 

--- a/app/services/creators/full_assessment_creator.rb
+++ b/app/services/creators/full_assessment_creator.rb
@@ -93,7 +93,7 @@ module Creators
         },
         lambda { |assessment, params|
           if params[:outgoings]
-            Creators::OutgoingsCreator.call(assessment:,
+            Creators::OutgoingsCreator.call(disposable_income_summary: assessment.disposable_income_summary,
                                             outgoings_params: { outgoings: params[:outgoings] })
           end
         },

--- a/app/services/creators/outgoings_creator.rb
+++ b/app/services/creators/outgoings_creator.rb
@@ -6,11 +6,11 @@ module Creators
       end
     end
     class << self
-      def call(assessment:, outgoings_params:)
+      def call(disposable_income_summary:, outgoings_params:)
         json_validator = JsonValidator.new("outgoings", outgoings_params)
         if json_validator.valid?
           ActiveRecord::Base.transaction do
-            outgoings_params[:outgoings].each { |outgoing| create_outgoing_collection(assessment, outgoing) }
+            outgoings_params[:outgoings].each { |outgoing| create_outgoing_collection(disposable_income_summary, outgoing) }
           end
           Result.new(errors: []).freeze
         else
@@ -22,11 +22,11 @@ module Creators
 
     private
 
-      def create_outgoing_collection(assessment, outgoing)
+      def create_outgoing_collection(disposable_income_summary, outgoing)
         klass = CFEConstants::OUTGOING_KLASSES[outgoing[:name].to_sym]
         payments = outgoing[:payments]
         payments.each do |payment_params|
-          klass.create! payment_params.merge(disposable_income_summary: assessment.disposable_income_summary)
+          klass.create! payment_params.merge(disposable_income_summary:)
         end
       end
     end

--- a/spec/fixtures/partner_financials.json
+++ b/spec/fixtures/partner_financials.json
@@ -58,7 +58,7 @@
       "subject_matter_of_dispute": false
     }
   ],
-  "capital_items": {
+  "capitals": {
     "bank_accounts": [
       {
         "value": 1.01,

--- a/spec/requests/partner_financials_controller_spec.rb
+++ b/spec/requests/partner_financials_controller_spec.rb
@@ -193,38 +193,17 @@ describe PartnerFinancialsController, :calls_bank_holiday, type: :request do
         ]
       end
 
-      it "produces a success response" do
-        expect(parsed_response).to eq(success: true, errors: [])
-      end
-
-      it "produces partner capital" do
+      before do
         post("/assessments/#{assessment.id}/employments", params: employments.to_json, headers:)
         post("/assessments/#{assessment.id}/proceeding_types", params: proceeding_types.to_json, headers:)
 
         get("/assessments/#{assessment.id}")
-        answer = JSON.parse(response.body, symbolize_names: true)
-        expect(answer[:success]).to eq(true)
-        summary = answer.fetch(:result_summary)
-        expect(summary.fetch(:overall_result).except(:proceeding_types))
+      end
+
+      it "uses the partner outgoings field" do
+        expect(parsed_response.dig(:assessment, :partner_disposable_income, :monthly_equivalents, :all_sources))
           .to eq({
-            result: "contribution_required",
-            capital_contribution: 0.0,
-            income_contribution: 614.1,
-          })
-        expect(summary.fetch(:partner_capital))
-          .to eq({
-            pensioner_disregard_applied: 0.0,
-            total_liquid: 620.0,
-            total_non_liquid: 0.0,
-            total_vehicle: 0.0,
-            total_property: 0.0,
-            total_mortgage_allowance: 999_999_999_999.0,
-            total_capital: 620.0,
-            subject_matter_of_dispute_disregard: 0.0,
-            capital_contribution: 0,
-            assessed_capital: 620.0,
-            total_capital_with_smod: 620.0,
-            disputed_non_property_disregard: 0.0,
+            child_care: 0.0, rent_or_mortgage: 600.0, maintenance_out: 0.0, legal_aid: 0.0
           })
       end
     end

--- a/spec/requests/partner_financials_controller_spec.rb
+++ b/spec/requests/partner_financials_controller_spec.rb
@@ -1,0 +1,232 @@
+require "rails_helper"
+
+describe PartnerFinancialsController, :calls_bank_holiday, type: :request do
+  let(:headers) { { "CONTENT_TYPE" => "application/json" } }
+  let(:assessment) { create :assessment, :with_applicant, :with_disposable_income_summary, :with_gross_income_summary, :with_capital_summary }
+  let(:date_of_birth) { Faker::Date.backward.to_s }
+
+  describe "POST /assessments/:assessment_id/partner_financials" do
+    before do
+      post assessment_partner_financials_path(assessment), params: partner_financials_params.to_json, headers:
+    end
+
+    context "with invalid vehicles" do
+      let(:partner_financials_params) do
+        {
+          partner: {
+            date_of_birth:,
+            employed: true,
+          },
+          vehicles: [
+            {
+              date_of_purchase: "2900-07-07",
+              value: 2000.0,
+            },
+          ],
+        }
+      end
+
+      it "returns error" do
+        expect(parsed_response[:errors]).to include(/Date of purchase cannot be in the future/)
+      end
+    end
+
+    context "with invalid capitals" do
+      let(:partner_financials_params) do
+        {
+          partner: {
+            date_of_birth:,
+            employed: true,
+          },
+          capitals: {
+            bank_accounts: [
+              {
+                value: 2000.0,
+              },
+            ],
+          },
+        }
+      end
+
+      it "returns error" do
+        expect(parsed_response[:errors]).to include(/The property '#\/bank_accounts\/0' did not contain a required property of 'description'/)
+      end
+    end
+
+    context "with outgoings" do
+      let(:partner_financials_params) do
+        {
+          partner: {
+            date_of_birth: "1980-11-20",
+            employed: true,
+          },
+          "dependants": [
+            {
+              "date_of_birth": "2022-11-20",
+              "in_full_time_education": false,
+              "relationship": "child_relative",
+              "monthly_income": 0,
+              "assets_value": 0,
+            },
+          ],
+          "employments": [
+            {
+              "name": "job-1-dec",
+              "client_id": "job1-id-uuid",
+              "payments": [
+                {
+                  "client_id": "job1-december-pay-uuid",
+                  "date": "2020-12-1",
+                  "gross": 450.00,
+                  "benefits_in_kind": 0,
+                  "tax": -10.04,
+                  "national_insurance": -5.02,
+                },
+                {
+                  "client_id": "job-1-november-pay-uuid",
+                  "date": "2020-11-01",
+                  "gross": 450.00,
+                  "benefits_in_kind": 0,
+                  "tax": -10.04,
+                  "national_insurance": -5.02,
+                },
+                {
+                  "client_id": "job-1-october-pay-uuid",
+                  "date": "2020-10-01",
+                  "gross": 450,
+                  "benefits_in_kind": 0,
+                  "tax": -10.04,
+                  "national_insurance": -5.02,
+                },
+              ],
+            },
+          ],
+          "outgoings": [
+            {
+              "name": "rent_or_mortgage",
+              "payments": [
+                {
+                  "payment_date": "2021-05-10",
+                  "amount": 600,
+                  "housing_cost_type": "rent",
+                  "client_id": "id7",
+                },
+                {
+                  "payment_date": "2021-04-10",
+                  "amount": 600,
+                  "housing_cost_type": "rent",
+                  "client_id": "id8",
+                },
+                {
+                  "payment_date": "2021-03-10",
+                  "amount": 600,
+                  "housing_cost_type": "rent",
+                  "client_id": "id9",
+                },
+              ],
+            },
+          ],
+          "capitals": {
+            "bank_accounts": [
+              {
+                "value": 420,
+                "description": "Bank acct 1",
+              },
+              {
+                "value": 200,
+                "description": "Bank acct 2",
+              },
+            ],
+          },
+        }
+      end
+      let(:employments) do
+        {
+          "employment_income": [
+            {
+              "name": "job-1-dec",
+              "client_id": "job1-id-uuid",
+              "payments": [
+                {
+                  "client_id": "job1-december-pay-uuid",
+                  "date": "2020-12-18",
+                  "gross": 2526.00,
+                  "benefits_in_kind": 0,
+                  "tax": -244.60,
+                  "national_insurance": -208.08,
+                },
+                {
+                  "client_id": "job-1-november-pay-uuid",
+                  "date": "2020-11-28",
+                  "gross": 2526.00,
+                  "benefits_in_kind": 0,
+                  "tax": -244.6,
+                  "national_insurance": -208.08,
+                },
+                {
+                  "client_id": "job-1-october-pay-uuid",
+                  "date": "2020-10-28",
+                  "gross": 2526.00,
+                  "benefits_in_kind": 0,
+                  "tax": -244.6,
+                  "national_insurance": -208.08,
+                },
+              ],
+            },
+          ],
+        }
+      end
+      let(:proceeding_types) do
+        [
+          {
+            "ccms_code": "DA001",
+            "client_involvement_type": "A",
+          },
+          {
+            "ccms_code": "SE013",
+            "client_involvement_type": "A",
+          },
+          {
+            "ccms_code": "SE003",
+            "client_involvement_type": "A",
+          },
+        ]
+      end
+
+      it "produces a success response" do
+        expect(parsed_response).to eq(success: true, errors: [])
+      end
+
+      it "produces partner capital" do
+        post("/assessments/#{assessment.id}/employments", params: employments.to_json, headers:)
+        post("/assessments/#{assessment.id}/proceeding_types", params: proceeding_types.to_json, headers:)
+
+        get("/assessments/#{assessment.id}")
+        answer = JSON.parse(response.body, symbolize_names: true)
+        expect(answer[:success]).to eq(true)
+        summary = answer.fetch(:result_summary)
+        expect(summary.fetch(:overall_result).except(:proceeding_types))
+          .to eq({
+            result: "contribution_required",
+            capital_contribution: 0.0,
+            income_contribution: 614.1,
+          })
+        expect(summary.fetch(:partner_capital))
+          .to eq({
+            pensioner_disregard_applied: 0.0,
+            total_liquid: 620.0,
+            total_non_liquid: 0.0,
+            total_vehicle: 0.0,
+            total_property: 0.0,
+            total_mortgage_allowance: 999_999_999_999.0,
+            total_capital: 620.0,
+            subject_matter_of_dispute_disregard: 0.0,
+            capital_contribution: 0,
+            assessed_capital: 620.0,
+            total_capital_with_smod: 620.0,
+            disputed_non_property_disregard: 0.0,
+          })
+      end
+    end
+  end
+end

--- a/spec/requests/swagger_docs/v5/cash_transactions_spec.rb
+++ b/spec/requests/swagger_docs/v5/cash_transactions_spec.rb
@@ -7,9 +7,7 @@ RSpec.describe "cash_transactions", type: :request, swagger_doc: "v5/swagger.yam
       consumes "application/json"
       produces "application/json"
 
-      description <<~DESCRIPTION.chomp
-        Add cash income and outgoings to an assessment.
-      DESCRIPTION
+      description << "Add cash income and outgoings to an assessment."
 
       assessment_id_parameter
 
@@ -64,46 +62,7 @@ RSpec.describe "cash_transactions", type: :request, swagger_doc: "v5/swagger.yam
                         },
                       },
                     },
-                    outgoings: {
-                      type: :array,
-                      description: "One or more outgoing details",
-                      items: {
-                        type: :object,
-                        description: "Outgoing detail",
-                        properties: {
-                          category: {
-                            type: :string,
-                            enum: CFEConstants::VALID_OUTGOING_CATEGORIES,
-                            example: CFEConstants::VALID_OUTGOING_CATEGORIES.first,
-                          },
-                          payments: {
-                            type: :array,
-                            description: "One or more payment details",
-                            items: {
-                              type: :object,
-                              description: "Payment detail",
-                              properties: {
-                                date: {
-                                  type: :string,
-                                  format: :date,
-                                  example: "1992-07-22",
-                                },
-                                amount: {
-                                  type: :number,
-                                  format: :decimal,
-                                  example: "101.02",
-                                },
-                                client_id: {
-                                  type: :string,
-                                  format: :uuid,
-                                  example: "05459c0f-a620-4743-9f0c-b3daa93e5711",
-                                },
-                              },
-                            },
-                          },
-                        },
-                      },
-                    },
+                    outgoings: { "$ref" => "#/components/schemas/OutgoingsList" },
                   },
                 }
 

--- a/spec/requests/swagger_docs/v5/full_assessment_spec.rb
+++ b/spec/requests/swagger_docs/v5/full_assessment_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe "full_assessment", type: :request, swagger_doc: "v5/swagger.yaml"
                     assessment: {
                       type: :object,
                       additionalProperties: false,
-                      required: %i[submission_date level_of_help],
+                      required: %i[submission_date],
                       properties: {
                         submission_date: {
                           type: :string,
@@ -41,25 +41,42 @@ RSpec.describe "full_assessment", type: :request, swagger_doc: "v5/swagger.yaml"
                           type: :string,
                           enum: Assessment.levels_of_help.keys,
                           example: Assessment.levels_of_help.keys.first,
-                          description: "The level of representation required by the client",
+                          description: "The level of representation required by the client. Defaults to 'certificated'",
                         },
                       },
                     },
                     applicant: {
                       type: :object,
+                      additionalProperties: false,
                       required: %i[date_of_birth has_partner_opponent receives_qualifying_benefit],
                       description: "Object describing pertinent applicant details",
                       properties: {
-                        date_of_birth: { type: :string,
-                                         format: :date,
-                                         example: "1992-07-22",
-                                         description: "Applicant date of birth" },
-                        has_partner_opponent: { type: :boolean,
-                                                example: false,
-                                                description: "Applicant has partner opponent" },
-                        receives_qualifying_benefit: { type: :boolean,
-                                                       example: false,
-                                                       description: "Applicant receives qualifying benefit" },
+                        date_of_birth: {
+                          type: :string,
+                          format: :date,
+                          example: "1992-07-22",
+                          description: "Applicant date of birth",
+                        },
+                        has_partner_opponent: {
+                          type: :boolean,
+                          example: false,
+                          description: "Applicant has partner opponent",
+                        },
+                        receives_qualifying_benefit: {
+                          type: :boolean,
+                          example: false,
+                          description: "Applicant receives qualifying benefit",
+                        },
+                        involvement_type: {
+                          type: :string,
+                          "enum": %w[applicant],
+                        },
+                        employed: {
+                          type: :boolean,
+                        },
+                        receives_asylum_support: {
+                          type: :boolean,
+                        },
                       },
                     },
                     proceeding_types: {
@@ -68,6 +85,7 @@ RSpec.describe "full_assessment", type: :request, swagger_doc: "v5/swagger.yaml"
                       minItems: 1,
                       items: {
                         type: :object,
+                        additionalProperties: false,
                         required: %i[ccms_code client_involvement_type],
                         properties: {
                           ccms_code: {
@@ -87,6 +105,7 @@ RSpec.describe "full_assessment", type: :request, swagger_doc: "v5/swagger.yaml"
                     capitals: { "$ref" => "#/components/schemas/Capitals" },
                     cash_transactions: {
                       type: :object,
+                      additionalProperties: false,
                       description: "A set of cash income[ings] and outgoings payments by category",
                       example: JSON.parse(File.read(Rails.root.join("spec/fixtures/cash_transactions.json"))
                                               .gsub("3.months.ago", "2022-03-01")
@@ -112,6 +131,7 @@ RSpec.describe "full_assessment", type: :request, swagger_doc: "v5/swagger.yaml"
                                 description: "One or more payment details",
                                 items: {
                                   type: :object,
+                                  additionalProperties: false,
                                   description: "Payment detail",
                                   required: %i[amount client_id date],
                                   properties: {
@@ -186,6 +206,7 @@ RSpec.describe "full_assessment", type: :request, swagger_doc: "v5/swagger.yaml"
                       description: "One or more dependants details",
                       items: {
                         type: :object,
+                        additionalProperties: false,
                         required: %i[date_of_birth in_full_time_education relationship],
                         properties: {
                           date_of_birth: {
@@ -224,6 +245,7 @@ RSpec.describe "full_assessment", type: :request, swagger_doc: "v5/swagger.yaml"
                       description: "One or more employment income details",
                       items: {
                         type: :object,
+                        additionalProperties: false,
                         description: "Employment income detail",
                         required: %i[name client_id payments],
                         properties: {
@@ -246,6 +268,8 @@ RSpec.describe "full_assessment", type: :request, swagger_doc: "v5/swagger.yaml"
                     irregular_incomes: {
                       type: :object,
                       description: "A set of irregular income payments",
+                      required: %i[payments],
+                      additionalProperties: false,
                       example: { payments: [{ income_type: "student_loan", frequency: "annual", amount: 123_456.78 }] },
                       properties: {
                         payments: {
@@ -287,6 +311,7 @@ RSpec.describe "full_assessment", type: :request, swagger_doc: "v5/swagger.yaml"
                       description: "One or more other regular income payments categorized by source",
                       items: {
                         type: :object,
+                        additionalProperties: false,
                         description: "Other regular income detail",
                         required: %i[source],
                         properties: {
@@ -302,6 +327,7 @@ RSpec.describe "full_assessment", type: :request, swagger_doc: "v5/swagger.yaml"
                             items: {
                               type: :object,
                               description: "Payment detail",
+                              additionalProperties: false,
                               required: %i[date amount client_id],
                               properties: {
                                 date: {
@@ -328,104 +354,7 @@ RSpec.describe "full_assessment", type: :request, swagger_doc: "v5/swagger.yaml"
                         },
                       },
                     },
-                    outgoings: {
-                      type: :array,
-                      description: "One or more outgoings categorized by name",
-                      items: {
-                        oneOf: [
-                          {
-                            type: :object,
-                            required: %i[name payments],
-                            additionalProperties: false,
-                            description: "Outgoing payments detail",
-                            properties: {
-                              name: {
-                                type: :string,
-                                enum: CFEConstants::NON_HOUSING_OUTGOING_CATEGORIES,
-                                description: "Type of outgoing",
-                                example: CFEConstants::NON_HOUSING_OUTGOING_CATEGORIES.first,
-                              },
-                              payments: {
-                                type: :array,
-                                description: "One or more outgoing payments detail",
-                                items: {
-                                  type: :object,
-                                  additionalProperties: false,
-                                  required: %i[client_id payment_date amount],
-                                  description: "Payment detail",
-                                  properties: {
-                                    client_id: {
-                                      type: :string,
-                                      description: "Client identifier for outgoing payment",
-                                      example: "05459c0f-a620-4743-9f0c-b3daa93e5711",
-                                    },
-                                    payment_date: {
-                                      type: :string,
-                                      format: :date,
-                                      description: "Date payment made",
-                                      example: "1992-07-22",
-                                    },
-                                    amount: {
-                                      type: :number,
-                                      format: :decimal,
-                                      description: "Amount of payment made",
-                                      example: 101.01,
-                                    },
-                                  },
-                                },
-                              },
-                            },
-                          },
-                          {
-                            type: :object,
-                            required: %i[name payments],
-                            additionalProperties: false,
-                            description: "Outgoing payments detail",
-                            properties: {
-                              name: {
-                                type: :string,
-                                enum: %w[rent_or_mortgage],
-                                description: "Type of outgoing",
-                              },
-                              payments: {
-                                type: :array,
-                                description: "One or more outgoing payments detail",
-                                items: {
-                                  type: :object,
-                                  additionalProperties: false,
-                                  required: %i[client_id payment_date amount housing_cost_type],
-                                  description: "Payment detail",
-                                  properties: {
-                                    client_id: {
-                                      type: :string,
-                                      description: "Client identifier for outgoing payment",
-                                      example: "05459c0f-a620-4743-9f0c-b3daa93e5711",
-                                    },
-                                    payment_date: {
-                                      type: :string,
-                                      format: :date,
-                                      description: "Date payment made",
-                                      example: "1992-07-22",
-                                    },
-                                    housing_cost_type: {
-                                      type: :string,
-                                      enum: CFEConstants::VALID_OUTGOING_HOUSING_COST_TYPES,
-                                      description: "Housing cost type",
-                                    },
-                                    amount: {
-                                      type: :number,
-                                      format: :decimal,
-                                      description: "Amount of payment made",
-                                      example: 101.01,
-                                    },
-                                  },
-                                },
-                              },
-                            },
-                          },
-                        ],
-                      },
-                    },
+                    outgoings: { "$ref" => "#/components/schemas/OutgoingsList" },
                     properties: {
                       type: :object,
                       required: %i[main_home],

--- a/spec/requests/swagger_docs/v5/outgoings_spec.rb
+++ b/spec/requests/swagger_docs/v5/outgoings_spec.rb
@@ -7,9 +7,7 @@ RSpec.describe "outgoings", type: :request, swagger_doc: "v5/swagger.yaml" do
       consumes "application/json"
       produces "application/json"
 
-      description <<~DESCRIPTION.chomp
-        Add applicant's outgoings to an assessment.
-      DESCRIPTION
+      description << "Add applicant's outgoings to an assessment."
 
       assessment_id_parameter
 
@@ -21,57 +19,7 @@ RSpec.describe "outgoings", type: :request, swagger_doc: "v5/swagger.yaml" do
                   description: "A set of outgoings sources",
                   example: JSON.parse(File.read(Rails.root.join("spec/fixtures/outgoings.json"))),
                   properties: {
-                    outgoings: {
-                      type: :array,
-                      required: %i[name payments],
-                      description: "One or more outgoings categorized by name",
-                      items: {
-                        type: :object,
-                        description: "Outgoing payments detail",
-                        properties: {
-                          name: {
-                            type: :string,
-                            enum: CFEConstants::VALID_OUTGOING_CATEGORIES,
-                            description: "Type of outgoing",
-                            example: CFEConstants::VALID_OUTGOING_CATEGORIES.first,
-                          },
-                          payments: {
-                            type: :array,
-                            required: %i[client_id payment_date amount],
-                            description: "One or more outgoing payments detail",
-                            items: {
-                              type: :object,
-                              description: "Payment detail",
-                              properties: {
-                                client_id: {
-                                  type: :string,
-                                  description: "Client identifier for outgoing payment",
-                                  example: "05459c0f-a620-4743-9f0c-b3daa93e5711",
-                                },
-                                payment_date: {
-                                  type: :string,
-                                  format: :date,
-                                  description: "Date payment made",
-                                  example: "1992-07-22",
-                                },
-                                housing_cost_type: {
-                                  type: :string,
-                                  enum: CFEConstants::VALID_OUTGOING_HOUSING_COST_TYPES,
-                                  description: "Housing cost type (omit for non-housing cost outgoings)",
-                                  example: CFEConstants::VALID_OUTGOING_HOUSING_COST_TYPES.first,
-                                },
-                                amount: {
-                                  type: :number,
-                                  format: :decimal,
-                                  description: "Amount of payment made",
-                                  example: 101.01,
-                                },
-                              },
-                            },
-                          },
-                        },
-                      },
-                    },
+                    outgoings: { "$ref" => "#/components/schemas/OutgoingsList" },
                   },
                 }
 

--- a/spec/requests/swagger_docs/v5/partner_financials_spec.rb
+++ b/spec/requests/swagger_docs/v5/partner_financials_spec.rb
@@ -7,9 +7,7 @@ RSpec.describe "partner_financials", type: :request, swagger_doc: "v5/swagger.ya
       consumes "application/json"
       produces "application/json"
 
-      description <<~DESCRIPTION.chomp
-        Adds details of an applicant's partner.
-      DESCRIPTION
+      description << "Adds details of an applicant's partner."
 
       assessment_id_parameter
 
@@ -21,6 +19,7 @@ RSpec.describe "partner_financials", type: :request, swagger_doc: "v5/swagger.ya
                   required: %i[partner],
                   description: "Full information about an applicant's partner",
                   example: JSON.parse(File.read(Rails.root.join("spec/fixtures/partner_financials.json"))),
+                  additionalProperties: false,
                   properties: {
                     partner: {
                       type: :object,
@@ -69,6 +68,7 @@ RSpec.describe "partner_financials", type: :request, swagger_doc: "v5/swagger.ya
                       },
                     },
                     employments: { "$ref" => "#/components/schemas/EmploymentPaymentList" },
+                    outgoings: { "$ref" => "#/components/schemas/OutgoingsList" },
                     regular_transactions: {
                       type: :array,
                       required: %i[category operation frequency amount],
@@ -195,7 +195,7 @@ RSpec.describe "partner_financials", type: :request, swagger_doc: "v5/swagger.ya
                         },
                       },
                     },
-                    capital_items: { "$ref" => "#/components/schemas/Capitals" },
+                    capitals: { "$ref" => "#/components/schemas/Capitals" },
                     vehicles: {
                       type: :array,
                       description: "One or more vehicles' details",
@@ -337,7 +337,7 @@ RSpec.describe "partner_financials", type: :request, swagger_doc: "v5/swagger.ya
                 subject_matter_of_dispute: false,
               },
             ],
-            capital_items: {
+            capitals: {
               bank_accounts: [
                 {
                   value: 1.01,

--- a/spec/requests/v2/assessments_controller_spec.rb
+++ b/spec/requests/v2/assessments_controller_spec.rb
@@ -424,20 +424,6 @@ module V2
 
       context "without dependants, cash transactions or employment income" do
         let(:payment_date) { "2022-05-15" }
-        let(:child_care_params) do
-          [
-            {
-              name: "child_care",
-              payments: [
-                {
-                  payment_date:,
-                  amount: Faker::Number.decimal(l_digits: 3, r_digits: 2),
-                  client_id: client_ids.first,
-                },
-              ],
-            },
-          ]
-        end
         let(:outgoings_params) do
           [
             {

--- a/spec/requests/v2/assessments_controller_spec.rb
+++ b/spec/requests/v2/assessments_controller_spec.rb
@@ -162,11 +162,7 @@ module V2
         end
 
         it "returns error JSON" do
-          expect(parsed_response)
-            .to eq({
-              success: false,
-              errors: ["The property '#/applicant' did not contain a required property of 'date_of_birth' in schema file://#"],
-            })
+          expect(parsed_response[:errors]).to include(%r{The property '#/applicant' did not contain a required property of 'date_of_birth'})
         end
       end
 
@@ -591,7 +587,7 @@ module V2
               ],
               state_benefits: state_benefit_params,
               additional_properties: properties_params,
-              outgoings: child_care_params,
+              outgoings: outgoings_params,
               capitals: {
                 bank_accounts: bank_account_params,
                 non_liquid_capital: non_liquid_params,
@@ -629,7 +625,7 @@ module V2
                 .to eq({
                   result: "contribution_required",
                   capital_contribution: 19_636.86,
-                  income_contribution: 377.81,
+                  income_contribution: 76.44,
                 })
             end
           end
@@ -643,7 +639,7 @@ module V2
                 {
                   dependant_allowance: 0.0,
                   gross_housing_costs: 117.16,
-                  income_contribution: 377.81,
+                  income_contribution: 76.44,
                   housing_benefit: 0.0,
                   net_housing_costs: 117.16,
                   maintenance_allowance: 333.07,
@@ -664,12 +660,12 @@ module V2
             expect(summary.fetch(:partner_disposable_income)).to eq(
               {
                 dependant_allowance: 615.28,
-                gross_housing_costs: 0.0,
+                gross_housing_costs: 117.16,
                 housing_benefit: 0.0,
-                net_housing_costs: 0.0,
-                maintenance_allowance: 0.0,
-                total_outgoings_and_allowances: 856.31,
-                total_disposable_income: 23.765,
+                net_housing_costs: 117.16,
+                maintenance_allowance: 333.07,
+                total_outgoings_and_allowances: 1322.87,
+                total_disposable_income: -442.795,
                 employment_income: {
                   gross_income: 546.0,
                   benefits_in_kind: 0.0,
@@ -901,16 +897,16 @@ module V2
               {
                 monthly_equivalents: {
                   all_sources: {
-                    child_care: 73.27,
-                    rent_or_mortgage: 0.0,
-                    maintenance_out: 0.0,
-                    legal_aid: 0.0,
+                    child_care: 82.98,
+                    rent_or_mortgage: 117.16,
+                    maintenance_out: 333.07,
+                    legal_aid: 6.62,
                   },
                   bank_transactions: {
-                    child_care: 0.0,
-                    rent_or_mortgage: 0.0,
-                    maintenance_out: 0.0,
-                    legal_aid: 0.0,
+                    child_care: 9.71,
+                    rent_or_mortgage: 117.16,
+                    maintenance_out: 333.07,
+                    legal_aid: 6.62,
                   },
                   cash_transactions: {
                     child_care: 0.0,
@@ -919,7 +915,7 @@ module V2
                     legal_aid: 0.0,
                   },
                 },
-                childcare_allowance: 73.27,
+                childcare_allowance: 82.98,
                 deductions: { dependants_allowance: 615.28, disregarded_state_benefits: 1033.44 },
               },
             )

--- a/spec/services/creators/outgoings_creator_spec.rb
+++ b/spec/services/creators/outgoings_creator_spec.rb
@@ -8,7 +8,7 @@ module Creators
       let(:housing_cost_type_rent) { "rent" }
       let(:housing_cost_type_mortgage) { "mortgage" }
 
-      subject(:creator) { described_class.call(assessment:, outgoings_params:) }
+      subject(:creator) { described_class.call(disposable_income_summary: assessment.disposable_income_summary, outgoings_params:) }
 
       it "creates all the required outgoing records" do
         expect { creator }.to change(Outgoings::BaseOutgoing, :count).by(6)

--- a/spec/services/creators/partner_financials_creator_spec.rb
+++ b/spec/services/creators/partner_financials_creator_spec.rb
@@ -406,34 +406,6 @@ module Creators
         end
       end
 
-      context "with invalid capitals" do
-        let(:partner_financials_params) do
-          {
-            partner: {
-              date_of_birth:,
-              employed: true,
-            },
-            capitals: {
-              bank_accounts: [
-                {
-                  description: "A",
-                  subject_matter_of_dispute: false,
-                },
-              ],
-              non_liquid_capital: [],
-            },
-          }
-        end
-
-        it "returns error" do
-          expect(creator.errors[0]).to include("value")
-        end
-
-        it "does not create any vehicles" do
-          expect { creator }.not_to change(LiquidCapitalItem, :count)
-        end
-      end
-
       context "with valid vehicles" do
         let(:partner_financials_params) do
           {

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -261,6 +261,104 @@ RSpec.configure do |config|
               description: "Description of asset",
             },
           },
+          OutgoingsList: {
+            type: :array,
+            description: "One or more outgoings categorized by name",
+            items: {
+              oneOf: [
+                {
+                  type: :object,
+                  required: %i[name payments],
+                  additionalProperties: false,
+                  description: "Outgoing payments detail",
+                  properties: {
+                    name: {
+                      type: :string,
+                      enum: CFEConstants::NON_HOUSING_OUTGOING_CATEGORIES,
+                      description: "Type of outgoing",
+                      example: CFEConstants::NON_HOUSING_OUTGOING_CATEGORIES.first,
+                    },
+                    payments: {
+                      type: :array,
+                      description: "One or more outgoing payments detail",
+                      items: {
+                        type: :object,
+                        additionalProperties: false,
+                        required: %i[client_id payment_date amount],
+                        description: "Payment detail",
+                        properties: {
+                          client_id: {
+                            type: :string,
+                            description: "Client identifier for outgoing payment",
+                            example: "05459c0f-a620-4743-9f0c-b3daa93e5711",
+                          },
+                          payment_date: {
+                            type: :string,
+                            format: :date,
+                            description: "Date payment made",
+                            example: "1992-07-22",
+                          },
+                          amount: {
+                            type: :number,
+                            format: :decimal,
+                            description: "Amount of payment made",
+                            example: 101.01,
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+                {
+                  type: :object,
+                  required: %i[name payments],
+                  additionalProperties: false,
+                  description: "Outgoing payments detail",
+                  properties: {
+                    name: {
+                      type: :string,
+                      enum: %w[rent_or_mortgage],
+                      description: "Type of outgoing",
+                    },
+                    payments: {
+                      type: :array,
+                      description: "One or more outgoing payments detail",
+                      items: {
+                        type: :object,
+                        additionalProperties: false,
+                        required: %i[client_id payment_date amount housing_cost_type],
+                        description: "Payment detail",
+                        properties: {
+                          client_id: {
+                            type: :string,
+                            description: "Client identifier for outgoing payment",
+                            example: "05459c0f-a620-4743-9f0c-b3daa93e5711",
+                          },
+                          payment_date: {
+                            type: :string,
+                            format: :date,
+                            description: "Date payment made",
+                            example: "1992-07-22",
+                          },
+                          housing_cost_type: {
+                            type: :string,
+                            enum: CFEConstants::VALID_OUTGOING_HOUSING_COST_TYPES,
+                            description: "Housing cost type",
+                          },
+                          amount: {
+                            type: :number,
+                            format: :decimal,
+                            description: "Amount of payment made",
+                            example: 101.01,
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              ],
+            },
+          },
         },
       },
       paths: {},

--- a/swagger/v5/swagger.yaml
+++ b/swagger/v5/swagger.yaml
@@ -265,6 +265,98 @@ components:
         type: number
         format: decimal
         description: Description of asset
+    OutgoingsList:
+      type: array
+      description: One or more outgoings categorized by name
+      items:
+        oneOf:
+        - type: object
+          required:
+          - name
+          - payments
+          additionalProperties: false
+          description: Outgoing payments detail
+          properties:
+            name:
+              type: string
+              enum:
+              - child_care
+              - maintenance_out
+              - legal_aid
+              description: Type of outgoing
+              example: child_care
+            payments:
+              type: array
+              description: One or more outgoing payments detail
+              items:
+                type: object
+                additionalProperties: false
+                required:
+                - client_id
+                - payment_date
+                - amount
+                description: Payment detail
+                properties:
+                  client_id:
+                    type: string
+                    description: Client identifier for outgoing payment
+                    example: '05459c0f-a620-4743-9f0c-b3daa93e5711'
+                  payment_date:
+                    type: string
+                    format: date
+                    description: Date payment made
+                    example: '1992-07-22'
+                  amount:
+                    type: number
+                    format: decimal
+                    description: Amount of payment made
+                    example: 101.01
+        - type: object
+          required:
+          - name
+          - payments
+          additionalProperties: false
+          description: Outgoing payments detail
+          properties:
+            name:
+              type: string
+              enum:
+              - rent_or_mortgage
+              description: Type of outgoing
+            payments:
+              type: array
+              description: One or more outgoing payments detail
+              items:
+                type: object
+                additionalProperties: false
+                required:
+                - client_id
+                - payment_date
+                - amount
+                - housing_cost_type
+                description: Payment detail
+                properties:
+                  client_id:
+                    type: string
+                    description: Client identifier for outgoing payment
+                    example: '05459c0f-a620-4743-9f0c-b3daa93e5711'
+                  payment_date:
+                    type: string
+                    format: date
+                    description: Date payment made
+                    example: '1992-07-22'
+                  housing_cost_type:
+                    type: string
+                    enum:
+                    - rent
+                    - mortgage
+                    - board_and_lodging
+                    description: Housing cost type
+                  amount:
+                    type: number
+                    format: decimal
+                    description: Amount of payment made
+                    example: 101.01
 paths:
   "/assessments/{assessment_id}/applicant":
     post:
@@ -410,7 +502,6 @@ paths:
       summary: create cash_transaction
       tags:
       - Assessment components
-      description: Add cash income and outgoings to an assessment.
       parameters:
       - name: assessment_id
         in: path
@@ -513,39 +604,7 @@ paths:
                               format: uuid
                               example: '05459c0f-a620-4743-9f0c-b3daa93e5711'
                 outgoings:
-                  type: array
-                  description: One or more outgoing details
-                  items:
-                    type: object
-                    description: Outgoing detail
-                    properties:
-                      category:
-                        type: string
-                        enum:
-                        - child_care
-                        - rent_or_mortgage
-                        - maintenance_out
-                        - legal_aid
-                        example: child_care
-                      payments:
-                        type: array
-                        description: One or more payment details
-                        items:
-                          type: object
-                          description: Payment detail
-                          properties:
-                            date:
-                              type: string
-                              format: date
-                              example: '1992-07-22'
-                            amount:
-                              type: number
-                              format: decimal
-                              example: '101.02'
-                            client_id:
-                              type: string
-                              format: uuid
-                              example: '05459c0f-a620-4743-9f0c-b3daa93e5711'
+                  "$ref": "#/components/schemas/OutgoingsList"
         required: true
   "/assessments/{assessment_id}/dependants":
     post:
@@ -1088,7 +1147,6 @@ paths:
                   additionalProperties: false
                   required:
                   - submission_date
-                  - level_of_help
                   properties:
                     submission_date:
                       type: string
@@ -1106,9 +1164,11 @@ paths:
                       - certificated
                       - controlled
                       example: certificated
-                      description: The level of representation required by the client
+                      description: The level of representation required by the client.
+                        Defaults to 'certificated'
                 applicant:
                   type: object
+                  additionalProperties: false
                   required:
                   - date_of_birth
                   - has_partner_opponent
@@ -1128,12 +1188,21 @@ paths:
                       type: boolean
                       example: false
                       description: Applicant receives qualifying benefit
+                    involvement_type:
+                      type: string
+                      enum:
+                      - applicant
+                    employed:
+                      type: boolean
+                    receives_asylum_support:
+                      type: boolean
                 proceeding_types:
                   type: array
                   description: One or more proceeding_type details
                   minItems: 1
                   items:
                     type: object
+                    additionalProperties: false
                     required:
                     - ccms_code
                     - client_involvement_type
@@ -1156,6 +1225,7 @@ paths:
                   "$ref": "#/components/schemas/Capitals"
                 cash_transactions:
                   type: object
+                  additionalProperties: false
                   description: A set of cash income[ings] and outgoings payments by
                     category
                   example:
@@ -1231,6 +1301,7 @@ paths:
                             description: One or more payment details
                             items:
                               type: object
+                              additionalProperties: false
                               description: Payment detail
                               required:
                               - amount
@@ -1296,6 +1367,7 @@ paths:
                   description: One or more dependants details
                   items:
                     type: object
+                    additionalProperties: false
                     required:
                     - date_of_birth
                     - in_full_time_education
@@ -1331,6 +1403,7 @@ paths:
                   description: One or more employment income details
                   items:
                     type: object
+                    additionalProperties: false
                     description: Employment income detail
                     required:
                     - name
@@ -1353,6 +1426,9 @@ paths:
                 irregular_incomes:
                   type: object
                   description: A set of irregular income payments
+                  required:
+                  - payments
+                  additionalProperties: false
                   example:
                     payments:
                     - income_type: student_loan
@@ -1403,6 +1479,7 @@ paths:
                     by source
                   items:
                     type: object
+                    additionalProperties: false
                     description: Other regular income detail
                     required:
                     - source
@@ -1428,6 +1505,7 @@ paths:
                         items:
                           type: object
                           description: Payment detail
+                          additionalProperties: false
                           required:
                           - date
                           - amount
@@ -1449,97 +1527,7 @@ paths:
                               description: Client identifier for payment received
                               example: '05459c0f-a620-4743-9f0c-b3daa93e5711'
                 outgoings:
-                  type: array
-                  description: One or more outgoings categorized by name
-                  items:
-                    oneOf:
-                    - type: object
-                      required:
-                      - name
-                      - payments
-                      additionalProperties: false
-                      description: Outgoing payments detail
-                      properties:
-                        name:
-                          type: string
-                          enum:
-                          - child_care
-                          - maintenance_out
-                          - legal_aid
-                          description: Type of outgoing
-                          example: child_care
-                        payments:
-                          type: array
-                          description: One or more outgoing payments detail
-                          items:
-                            type: object
-                            additionalProperties: false
-                            required:
-                            - client_id
-                            - payment_date
-                            - amount
-                            description: Payment detail
-                            properties:
-                              client_id:
-                                type: string
-                                description: Client identifier for outgoing payment
-                                example: '05459c0f-a620-4743-9f0c-b3daa93e5711'
-                              payment_date:
-                                type: string
-                                format: date
-                                description: Date payment made
-                                example: '1992-07-22'
-                              amount:
-                                type: number
-                                format: decimal
-                                description: Amount of payment made
-                                example: 101.01
-                    - type: object
-                      required:
-                      - name
-                      - payments
-                      additionalProperties: false
-                      description: Outgoing payments detail
-                      properties:
-                        name:
-                          type: string
-                          enum:
-                          - rent_or_mortgage
-                          description: Type of outgoing
-                        payments:
-                          type: array
-                          description: One or more outgoing payments detail
-                          items:
-                            type: object
-                            additionalProperties: false
-                            required:
-                            - client_id
-                            - payment_date
-                            - amount
-                            - housing_cost_type
-                            description: Payment detail
-                            properties:
-                              client_id:
-                                type: string
-                                description: Client identifier for outgoing payment
-                                example: '05459c0f-a620-4743-9f0c-b3daa93e5711'
-                              payment_date:
-                                type: string
-                                format: date
-                                description: Date payment made
-                                example: '1992-07-22'
-                              housing_cost_type:
-                                type: string
-                                enum:
-                                - rent
-                                - mortgage
-                                - board_and_lodging
-                                description: Housing cost type
-                              amount:
-                                type: number
-                                format: decimal
-                                description: Amount of payment made
-                                example: 101.01
+                  "$ref": "#/components/schemas/OutgoingsList"
                 properties:
                   type: object
                   required:
@@ -1790,7 +1778,7 @@ paths:
                       percentage_owned: 100
                       shared_with_housing_assoc: false
                       subject_matter_of_dispute: false
-                    capital_items:
+                    capitals:
                       bank_accounts:
                       - value: 1.01
                         description: F
@@ -2261,7 +2249,6 @@ paths:
       summary: create outgoing
       tags:
       - Assessment components
-      description: Add applicant's outgoings to an assessment.
       parameters:
       - name: assessment_id
         in: path
@@ -2310,65 +2297,13 @@ paths:
                     client_id: 6e87193e-3f3e-4187-aae8-14a937793221
               properties:
                 outgoings:
-                  type: array
-                  required:
-                  - name
-                  - payments
-                  description: One or more outgoings categorized by name
-                  items:
-                    type: object
-                    description: Outgoing payments detail
-                    properties:
-                      name:
-                        type: string
-                        enum:
-                        - child_care
-                        - rent_or_mortgage
-                        - maintenance_out
-                        - legal_aid
-                        description: Type of outgoing
-                        example: child_care
-                      payments:
-                        type: array
-                        required:
-                        - client_id
-                        - payment_date
-                        - amount
-                        description: One or more outgoing payments detail
-                        items:
-                          type: object
-                          description: Payment detail
-                          properties:
-                            client_id:
-                              type: string
-                              description: Client identifier for outgoing payment
-                              example: '05459c0f-a620-4743-9f0c-b3daa93e5711'
-                            payment_date:
-                              type: string
-                              format: date
-                              description: Date payment made
-                              example: '1992-07-22'
-                            housing_cost_type:
-                              type: string
-                              enum:
-                              - rent
-                              - mortgage
-                              - board_and_lodging
-                              description: Housing cost type (omit for non-housing
-                                cost outgoings)
-                              example: rent
-                            amount:
-                              type: number
-                              format: decimal
-                              description: Amount of payment made
-                              example: 101.01
+                  "$ref": "#/components/schemas/OutgoingsList"
         required: true
   "/assessments/{assessment_id}/partner_financials":
     post:
       summary: 'create '
       tags:
       - Assessment components
-      description: Adds details of an applicant's partner.
       parameters:
       - name: assessment_id
         in: path
@@ -2426,7 +2361,7 @@ paths:
                   percentage_owned: 100
                   shared_with_housing_assoc: false
                   subject_matter_of_dispute: false
-                capital_items:
+                capitals:
                   bank_accounts:
                   - value: 1.01
                     description: F
@@ -2441,6 +2376,7 @@ paths:
                   date_of_purchase: '2017-01-23'
                   in_regular_use: true
                   subject_matter_of_dispute: false
+              additionalProperties: false
               properties:
                 partner:
                   type: object
@@ -2490,6 +2426,8 @@ paths:
                         example: 101.01
                 employments:
                   "$ref": "#/components/schemas/EmploymentPaymentList"
+                outgoings:
+                  "$ref": "#/components/schemas/OutgoingsList"
                 regular_transactions:
                   type: array
                   required:
@@ -2626,7 +2564,7 @@ paths:
                       subject_matter_of_dispute:
                         type: boolean
                         description: Property is the subject of a dispute
-                capital_items:
+                capitals:
                   "$ref": "#/components/schemas/Capitals"
                 vehicles:
                   type: array


### PR DESCRIPTION
https://dsdmoj.atlassian.net/browse/LEP-81

Add 'outgoings' section to partner_financials endpoint to match 'outgoings' endpoint in existing API. 
Fix-up documentation for 'capitals' section of partner_financials (capitals rather than capital_items)
