### PR TITLE
LEP-6: Remove property calculations from database table

### DIFF
--- a/app/services/calculators/property_calculator.rb
+++ b/app/services/calculators/property_calculator.rb
@@ -42,10 +42,7 @@ module Calculators
                        main_home_equity_disregard: equity_disregard.applied,
                        property:,
                        smod_allowance: smod_disregard.applied,
-                       assessed_equity: equity_disregard.result)
-                  .freeze.tap do |result|
-              save!(property, result)
-            end
+                       assessed_equity: equity_disregard.result).freeze
           end
         end
       end
@@ -62,11 +59,6 @@ module Calculators
       def main_home_equity_disregard_cap(property, submission_date)
         property_type = property.main_home ? :main_home : :additional_property
         Threshold.value_for(:property_disregard, at: submission_date)[property_type]
-      end
-
-      # TODO: Remove this side effect
-      def save!(property, result)
-        property.update!(result.to_h.except(:smod_allowance, :property))
       end
     end
   end

--- a/db/migrate/20230329105231_remove_property_results.rb
+++ b/db/migrate/20230329105231_remove_property_results.rb
@@ -1,0 +1,10 @@
+class RemovePropertyResults < ActiveRecord::Migration[7.0]
+  def change
+    change_table :properties, bulk: true do |t|
+      t.remove :transaction_allowance, :net_value, :net_equity, :main_home_equity_disregard,
+               type: :decimal, default: 0, null: false
+      t.remove :assessed_equity,
+               type: :decimal
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_03_27_082347) do
+ActiveRecord::Schema[7.0].define(version: 2023_03_29_105231) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -274,11 +274,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_27_082347) do
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
     t.uuid "capital_summary_id"
-    t.decimal "transaction_allowance", default: "0.0", null: false
-    t.decimal "net_value", default: "0.0", null: false
-    t.decimal "net_equity", default: "0.0", null: false
-    t.decimal "assessed_equity"
-    t.decimal "main_home_equity_disregard", default: "0.0", null: false
     t.boolean "subject_matter_of_dispute"
     t.index ["capital_summary_id"], name: "index_properties_on_capital_summary_id"
   end

--- a/spec/services/calculators/subject_matter_of_dispute_disregard_calculator_spec.rb
+++ b/spec/services/calculators/subject_matter_of_dispute_disregard_calculator_spec.rb
@@ -10,12 +10,10 @@ module Calculators
     let(:capital_summary) do
       create :capital_summary,
              vehicles: [vehicle],
-             capital_items: [capital_item],
-             properties: [property]
+             capital_items: [capital_item]
     end
     let(:vehicle) { create :vehicle, subject_matter_of_dispute: false }
     let(:capital_item) { create :liquid_capital_item, subject_matter_of_dispute: false }
-    let(:property) { create :property, subject_matter_of_dispute: false }
     let(:maximum_disregard) { 10_000 }
 
     describe "#value" do
@@ -44,7 +42,6 @@ module Calculators
       context "with multiple SMOD assets worth less than the disregard" do
         let(:capital_item) { create :liquid_capital_item, value: 3_000, subject_matter_of_dispute: true }
         let(:vehicle) { create :vehicle, assessed_value: 1_000, subject_matter_of_dispute: true }
-        let(:property) { create :property, assessed_equity: 5_000, subject_matter_of_dispute: true }
 
         it "returns the combined value of the assets" do
           expect(value).to eq 4_000
@@ -54,7 +51,6 @@ module Calculators
       context "with multiple SMOD assets worth more than the disregard" do
         let(:capital_item) { create :liquid_capital_item, value: 3_000, subject_matter_of_dispute: true }
         let(:vehicle) { create :vehicle, assessed_value: 1_000, subject_matter_of_dispute: true }
-        let(:property) { create :property, assessed_equity: 9_000, subject_matter_of_dispute: true }
 
         it "returns the disregard value" do
           expect(value).to eq 4_000
@@ -64,7 +60,6 @@ module Calculators
       context "if there is no valid upper limit provided" do
         let(:capital_item) { create :liquid_capital_item, value: 3_000, subject_matter_of_dispute: true }
         let(:vehicle) { create :vehicle, assessed_value: 1_000, subject_matter_of_dispute: true }
-        let(:property) { create :property, assessed_equity: 9_000, subject_matter_of_dispute: true }
         let(:maximum_disregard) { nil }
 
         it "raises an exception" do

--- a/spec/services/decorators/v5/property_decorator_spec.rb
+++ b/spec/services/decorators/v5/property_decorator_spec.rb
@@ -21,12 +21,7 @@ module Decorators
                    outstanding_mortgage: 454_533.64,
                    percentage_owned: 100.0,
                    main_home: true,
-                   shared_with_housing_assoc: false,
-                   transaction_allowance: 23_577.0,
-                   net_value: 697_523.0,
-                   net_equity: 697_523.0,
-                   main_home_equity_disregard: 100_000,
-                   assessed_equity: 597_523.0
+                   shared_with_housing_assoc: false
           end
           let(:property) do
             result = Calculators::PropertyCalculator.call(submission_date: Date.current, properties: [record],


### PR DESCRIPTION
https://dsdmoj.atlassian.net/browse/LEP-6

As part of removing the persistence from CFE, remove the calculated property fields from the database as they are already returned and used by the decorator