### PR TITLE
LEP-71 assessment timestamp should be recorded less accurately

### DIFF
--- a/db/migrate/20230331170201_remove_and_update_timestamp_columns.rb
+++ b/db/migrate/20230331170201_remove_and_update_timestamp_columns.rb
@@ -1,0 +1,57 @@
+class RemoveAndUpdateTimestampColumns < ActiveRecord::Migration[7.0]
+  RESOURCES = %i[
+    applicants
+    bank_holidays
+    capital_items
+    capital_summaries
+    cash_transaction_categories
+    cash_transactions
+    dependants
+    disposable_income_summaries
+    eligibilities
+    employment_payments
+    employments
+    explicit_remarks
+    gross_income_summaries
+    irregular_income_payments
+    other_income_payments
+    other_income_sources
+    outgoings
+    partners
+    proceeding_types
+    properties
+    regular_transactions
+    request_logs
+    state_benefit_payments
+    state_benefit_types
+    state_benefits
+    vehicles
+  ].freeze
+
+  def up
+    change_table :assessments, bulk: true do |t|
+      t.change :created_at, :date
+      t.change :updated_at, :date
+    end
+
+    RESOURCES.each do |resource|
+      change_table resource, bulk: true do |t|
+        t.remove :created_at, :updated_at, type: :datetime
+      end
+    end
+  end
+
+  def down
+    change_table :assessments, bulk: true do |t|
+      t.change :created_at, :datetime, precision: nil, null: false
+      t.change :updated_at, :datetime, precision: nil, null: false
+    end
+
+    RESOURCES.each do |resource|
+      change_table resource, bulk: true do |t|
+        t.column :created_at, :datetime, null: %i[state_benefit_types].any?(resource)
+        t.column :updated_at, :datetime, null: %i[state_benefit_types].any?(resource)
+      end
+    end
+  end
+end

--- a/db/migrate/20230331170201_remove_and_update_timestamp_columns.rb
+++ b/db/migrate/20230331170201_remove_and_update_timestamp_columns.rb
@@ -1,7 +1,6 @@
 class RemoveAndUpdateTimestampColumns < ActiveRecord::Migration[7.0]
   RESOURCES = %i[
     applicants
-    bank_holidays
     capital_items
     capital_summaries
     cash_transaction_categories

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -50,6 +50,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_31_170201) do
 
   create_table "bank_holidays", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.text "dates"
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
   end
 
   create_table "capital_items", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_03_29_105231) do
+ActiveRecord::Schema[7.0].define(version: 2023_03_31_170201) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -21,8 +21,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_29_105231) do
     t.string "involvement_type"
     t.boolean "has_partner_opponent"
     t.boolean "receives_qualifying_benefit"
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
     t.boolean "self_employed", default: false
     t.boolean "employed"
     t.boolean "receives_asylum_support", default: false, null: false
@@ -40,8 +38,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_29_105231) do
   create_table "assessments", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "client_reference_id"
     t.inet "remote_ip", null: false
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.date "created_at", null: false
+    t.date "updated_at", null: false
     t.date "submission_date", null: false
     t.string "assessment_result", default: "pending", null: false
     t.text "remarks"
@@ -52,8 +50,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_29_105231) do
 
   create_table "bank_holidays", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.text "dates"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
   end
 
   create_table "capital_items", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -61,16 +57,12 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_29_105231) do
     t.string "type", null: false
     t.string "description", null: false
     t.decimal "value", default: "0.0", null: false
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
     t.boolean "subject_matter_of_dispute"
     t.index ["capital_summary_id"], name: "index_capital_items_on_capital_summary_id"
   end
 
   create_table "capital_summaries", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "assessment_id"
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
     t.string "type", default: "ApplicantCapitalSummary"
     t.index ["assessment_id"], name: "index_capital_summaries_on_assessment_id"
   end
@@ -79,8 +71,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_29_105231) do
     t.uuid "gross_income_summary_id"
     t.string "operation"
     t.string "name"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
     t.index ["gross_income_summary_id", "name", "operation"], name: "index_cash_transaction_categories_uniqueness", unique: true
     t.index ["gross_income_summary_id"], name: "index_cash_transaction_categories_on_gross_income_summary_id"
   end
@@ -90,8 +80,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_29_105231) do
     t.date "date"
     t.decimal "amount"
     t.string "client_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
     t.index ["cash_transaction_category_id"], name: "index_cash_transactions_on_cash_transaction_category_id"
   end
 
@@ -99,8 +87,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_29_105231) do
     t.uuid "assessment_id"
     t.date "date_of_birth"
     t.boolean "in_full_time_education"
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
     t.string "relationship"
     t.decimal "monthly_income"
     t.decimal "assets_value"
@@ -116,8 +102,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_29_105231) do
     t.decimal "lower_threshold", default: "0.0", null: false
     t.decimal "upper_threshold", default: "0.0", null: false
     t.string "assessment_result", default: "pending", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
     t.decimal "net_housing_costs", default: "0.0"
     t.decimal "housing_benefit", default: "0.0"
     t.decimal "income_contribution", default: "0.0"
@@ -146,8 +130,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_29_105231) do
     t.decimal "lower_threshold"
     t.decimal "upper_threshold"
     t.string "assessment_result", default: "pending", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
     t.index ["parent_id", "type", "proceeding_type_code"], name: "eligibilities_unique_type_ptc", unique: true
   end
 
@@ -158,8 +140,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_29_105231) do
     t.decimal "benefits_in_kind", default: "0.0", null: false
     t.decimal "tax", default: "0.0", null: false
     t.decimal "national_insurance", default: "0.0", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
     t.string "client_id", null: false
     t.decimal "gross_income_monthly_equiv", default: "0.0", null: false
     t.decimal "tax_monthly_equiv", default: "0.0", null: false
@@ -170,8 +150,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_29_105231) do
   create_table "employments", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "assessment_id"
     t.string "name"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
     t.decimal "monthly_gross_income", default: "0.0", null: false
     t.decimal "monthly_benefits_in_kind", default: "0.0", null: false
     t.decimal "monthly_tax", default: "0.0", null: false
@@ -187,14 +165,10 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_29_105231) do
     t.uuid "assessment_id"
     t.string "category"
     t.string "remark"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
   end
 
   create_table "gross_income_summaries", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "assessment_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
     t.string "type", default: "ApplicantGrossIncomeSummary"
     t.index ["assessment_id"], name: "index_gross_income_summaries_on_assessment_id"
   end
@@ -204,8 +178,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_29_105231) do
     t.string "income_type", null: false
     t.string "frequency", null: false
     t.decimal "amount", default: "0.0"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
     t.index ["gross_income_summary_id", "income_type"], name: "irregular_income_payments_unique", unique: true
     t.index ["gross_income_summary_id"], name: "index_irregular_income_payments_on_gross_income_summary_id"
   end
@@ -215,8 +187,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_29_105231) do
     t.date "payment_date", null: false
     t.decimal "amount", null: false
     t.boolean "assessment_error", default: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
     t.string "client_id"
     t.index ["other_income_source_id"], name: "index_other_income_payments_on_other_income_source_id"
   end
@@ -224,8 +194,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_29_105231) do
   create_table "other_income_sources", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "gross_income_summary_id", null: false
     t.string "name", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
     t.decimal "monthly_income"
     t.boolean "assessment_error", default: false
     t.index ["gross_income_summary_id"], name: "index_other_income_sources_on_gross_income_summary_id"
@@ -237,8 +205,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_29_105231) do
     t.date "payment_date", null: false
     t.decimal "amount", null: false
     t.string "housing_cost_type"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
     t.string "client_id"
     t.index ["disposable_income_summary_id"], name: "index_outgoings_on_disposable_income_summary_id"
   end
@@ -247,8 +213,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_29_105231) do
     t.uuid "assessment_id", null: false
     t.date "date_of_birth"
     t.boolean "employed"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
     t.index ["assessment_id"], name: "index_partners_on_assessment_id"
   end
 
@@ -256,8 +220,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_29_105231) do
     t.uuid "assessment_id"
     t.string "ccms_code", null: false
     t.string "client_involvement_type", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
     t.decimal "gross_income_upper_threshold"
     t.decimal "disposable_income_upper_threshold"
     t.decimal "capital_upper_threshold"
@@ -271,8 +233,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_29_105231) do
     t.decimal "percentage_owned"
     t.boolean "main_home"
     t.boolean "shared_with_housing_assoc"
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
     t.uuid "capital_summary_id"
     t.boolean "subject_matter_of_dispute"
     t.index ["capital_summary_id"], name: "index_properties_on_capital_summary_id"
@@ -284,8 +244,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_29_105231) do
     t.string "operation"
     t.decimal "amount"
     t.string "frequency"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
     t.index ["gross_income_summary_id"], name: "index_regular_transactions_on_gross_income_summary_id"
   end
 
@@ -297,16 +255,12 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_29_105231) do
     t.integer "http_status"
     t.string "response"
     t.decimal "duration"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
   end
 
   create_table "state_benefit_payments", force: :cascade do |t|
     t.uuid "state_benefit_id", null: false
     t.date "payment_date", null: false
     t.decimal "amount", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
     t.string "client_id"
     t.json "flags"
     t.index ["state_benefit_id"], name: "index_state_benefit_payments_on_state_benefit_id"
@@ -316,8 +270,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_29_105231) do
     t.string "label"
     t.text "name"
     t.boolean "exclude_from_gross_income"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
     t.string "dwp_code"
     t.string "category"
     t.index ["dwp_code"], name: "index_state_benefit_types_on_dwp_code", unique: true
@@ -328,8 +280,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_29_105231) do
     t.uuid "gross_income_summary_id", null: false
     t.uuid "state_benefit_type_id", null: false
     t.string "name"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
     t.decimal "monthly_value", default: "0.0", null: false
     t.index ["gross_income_summary_id"], name: "index_state_benefits_on_gross_income_summary_id"
     t.index ["state_benefit_type_id"], name: "index_state_benefits_on_state_benefit_type_id"
@@ -340,8 +290,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_29_105231) do
     t.decimal "loan_amount_outstanding"
     t.date "date_of_purchase"
     t.boolean "in_regular_use"
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
     t.uuid "capital_summary_id"
     t.boolean "included_in_assessment", default: false, null: false
     t.decimal "assessed_value"

--- a/spec/models/assessment_spec.rb
+++ b/spec/models/assessment_spec.rb
@@ -14,9 +14,10 @@ RSpec.describe Assessment, type: :model do
       }
     end
 
-    it "writes a valid record" do
+    it "writes current date into the date column" do
       assessment = described_class.create! param_hash
-      expect(assessment).to be_valid
+      expect(assessment.created_at).to eq(Date.current)
+      expect(assessment.updated_at).to eq(Date.current)
     end
   end
 

--- a/spec/services/creators/capitals_creator_spec.rb
+++ b/spec/services/creators/capitals_creator_spec.rb
@@ -39,14 +39,9 @@ module Creators
 
         it "creates liquid capital items" do
           expect(capital_summary.liquid_capital_items.size).to eq 2
-          items = capital_summary.liquid_capital_items.order(:created_at)
-
-          expect(items.first.description).to eq bank_name1
-          expect(items.first.value).to eq value1
-          expect(items.first.subject_matter_of_dispute).to eq smod_true
-          expect(items.last.description).to eq bank_name2
-          expect(items.last.value).to eq value2
-          expect(items.last.subject_matter_of_dispute).to eq smod_false
+          expect(capital_summary.liquid_capital_items.collect(&:description)).to match_array [bank_name1, bank_name2]
+          expect(capital_summary.liquid_capital_items.collect(&:value)).to match_array [value1, value2]
+          expect(capital_summary.liquid_capital_items.collect(&:subject_matter_of_dispute)).to match_array [smod_true, smod_false]
         end
 
         it "does not create non-liquid capital items" do

--- a/spec/services/creators/capitals_creator_spec.rb
+++ b/spec/services/creators/capitals_creator_spec.rb
@@ -42,6 +42,8 @@ module Creators
           expect(capital_summary.liquid_capital_items.collect(&:description)).to match_array [bank_name1, bank_name2]
           expect(capital_summary.liquid_capital_items.collect(&:value)).to match_array [value1, value2]
           expect(capital_summary.liquid_capital_items.collect(&:subject_matter_of_dispute)).to match_array [smod_true, smod_false]
+          expect(capital_summary.liquid_capital_items.first.has_attribute?(:created_at)).to be false
+          expect(capital_summary.liquid_capital_items.first.has_attribute?(:updated_at)).to be false
         end
 
         it "does not create non-liquid capital items" do
@@ -60,6 +62,8 @@ module Creators
           expect(capital_summary.non_liquid_capital_items.first.description).to eq item1
           expect(capital_summary.non_liquid_capital_items.first.value).to eq value1
           expect(capital_summary.non_liquid_capital_items.first.subject_matter_of_dispute).to eq smod_true
+          expect(capital_summary.non_liquid_capital_items.first.has_attribute?(:created_at)).to be false
+          expect(capital_summary.non_liquid_capital_items.first.has_attribute?(:updated_at)).to be false
         end
       end
     end

--- a/spec/services/creators/capitals_creator_spec.rb
+++ b/spec/services/creators/capitals_creator_spec.rb
@@ -42,8 +42,6 @@ module Creators
           expect(capital_summary.liquid_capital_items.collect(&:description)).to match_array [bank_name1, bank_name2]
           expect(capital_summary.liquid_capital_items.collect(&:value)).to match_array [value1, value2]
           expect(capital_summary.liquid_capital_items.collect(&:subject_matter_of_dispute)).to match_array [smod_true, smod_false]
-          expect(capital_summary.liquid_capital_items.first.has_attribute?(:created_at)).to be false
-          expect(capital_summary.liquid_capital_items.first.has_attribute?(:updated_at)).to be false
         end
 
         it "does not create non-liquid capital items" do
@@ -62,8 +60,6 @@ module Creators
           expect(capital_summary.non_liquid_capital_items.first.description).to eq item1
           expect(capital_summary.non_liquid_capital_items.first.value).to eq value1
           expect(capital_summary.non_liquid_capital_items.first.subject_matter_of_dispute).to eq smod_true
-          expect(capital_summary.non_liquid_capital_items.first.has_attribute?(:created_at)).to be false
-          expect(capital_summary.non_liquid_capital_items.first.has_attribute?(:updated_at)).to be false
         end
       end
     end


### PR DESCRIPTION
## What

[LEP-71](https://dsdmoj.atlassian.net/browse/LEP-71)

**We need to remove/update timestamp so that the time can’t be correlated with CCQ logs**
- Change timestamp column for `assessments` from `datetime` to `date`
- Remove timestamp column from all tables, apart from `assessments` and `bank_holidays`

[LEP-71]: https://dsdmoj.atlassian.net/browse/LEP-71?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ