### PR TITLE
Change test not to rely on Date.current

### DIFF
--- a/spec/services/collators/childcare_collator_spec.rb
+++ b/spec/services/collators/childcare_collator_spec.rb
@@ -6,10 +6,10 @@ module Collators
       let(:assessment) { create :assessment, :with_disposable_income_summary, :with_gross_income_summary }
       let(:disposable_income_summary) { assessment.disposable_income_summary }
       let(:gross_income_summary) { assessment.gross_income_summary }
-      let(:target_time) { Date.current }
+
       let(:childcare_outgoings) do
         [
-          build(:childcare_outgoing, payment_date: Date.yesterday, amount: 155.63),
+          build(:childcare_outgoing, payment_date: Date.current, amount: 155.63),
           build(:childcare_outgoing, payment_date: 1.month.ago, amount: 155.63),
           build(:childcare_outgoing, payment_date: 2.months.ago, amount: 155.63),
         ]
@@ -21,7 +21,6 @@ module Collators
       end
 
       before do
-        travel_to target_time
         create :bank_holiday
       end
 


### PR DESCRIPTION
One stray spec started failing on 4-4-2023 due to it relying on things not changing and Date.current