### PR TITLE
LEP-57 defect - net_employment_income should be currency

### DIFF
--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -239,7 +239,7 @@ RSpec.configure do |config|
                   example: -5.24,
                 },
                 net_employment_income: {
-                  type: :number,
+                  "$ref" => "#/components/schemas/currency",
                   description: "Legacy field not used in calculation",
                 },
               },

--- a/swagger/v5/swagger.yaml
+++ b/swagger/v5/swagger.yaml
@@ -254,7 +254,7 @@ components:
               can be positive for a tax refund
             example: -5.24
           net_employment_income:
-            type: number
+            "$ref": "#/components/schemas/currency"
             description: Legacy field not used in calculation
     Asset:
       type: object


### PR DESCRIPTION
https://dsdmoj.atlassian.net/browse/LEP-57

Fix a bug where legacy field in partner employment was marked as numeric rather than currency