### PR TITLE
LEP-82 - Replace colorize gem with rainbow

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -74,7 +74,6 @@ group :development, :test do
   gem "byebug", platforms: %i[mri mingw x64_mingw]
   gem "hashdiff"
   gem "pry-byebug"
-  gem "rainbow"
   gem "rspec_junit_formatter"
   gem "rspec-rails", "~> 6.0", ">= 6.0.1"
   gem "rswag-specs"

--- a/Gemfile
+++ b/Gemfile
@@ -35,7 +35,6 @@ gem "business", "~> 2.3"
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin AJAX possible
 # gem 'rack-cors'
 
-gem "colorize"
 gem "date_validator"
 
 gem "api_error_handler"
@@ -75,6 +74,7 @@ group :development, :test do
   gem "byebug", platforms: %i[mri mingw x64_mingw]
   gem "hashdiff"
   gem "pry-byebug"
+  gem "rainbow"
   gem "rspec_junit_formatter"
   gem "rspec-rails", "~> 6.0", ">= 6.0.1"
   gem "rswag-specs"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -534,7 +534,6 @@ DEPENDENCIES
   pry-stack_explorer
   puma (~> 6.2)
   rails (~> 7.0.4, >= 7.0.4.3)
-  rainbow
   roo (~> 2.10.0)
   rspec-rails (~> 6.0, >= 6.0.1)
   rspec_junit_formatter

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -99,7 +99,6 @@ GEM
     case_transform (0.2)
       activesupport
     coderay (1.1.3)
-    colorize (0.8.1)
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
@@ -505,7 +504,6 @@ DEPENDENCIES
   bootsnap (>= 1.1.0)
   business (~> 2.3)
   byebug
-  colorize
   cucumber-rails
   database_cleaner
   date_validator
@@ -536,6 +534,7 @@ DEPENDENCIES
   pry-stack_explorer
   puma (~> 6.2)
   rails (~> 7.0.4, >= 7.0.4.3)
+  rainbow
   roo (~> 2.10.0)
   rspec-rails (~> 6.0, >= 6.0.1)
   rspec_junit_formatter

--- a/config/initializers/rainbow.rb
+++ b/config/initializers/rainbow.rb
@@ -1,0 +1,1 @@
+Rainbow.enabled = (Rails.env.development? || Rails.env.test?)

--- a/config/initializers/rainbow.rb
+++ b/config/initializers/rainbow.rb
@@ -1,1 +1,0 @@
-Rainbow.enabled = (Rails.env.development? || Rails.env.test?)


### PR DESCRIPTION
## What

[LEP-82](https://dsdmoj.atlassian.net/browse/LEP-82)

- Replace `colorize` gem wirh `rainbow` because snyk highlighted [this issue](https://app.snyk.io/org/legal-aid-agency/project/a84bdfb6-d142-4618-86a9-395a5b9903da#issue-snyk:lic:rubygems:colorize:GPL-2.0)
- `rainbow` is already a dependency of `undercover` and `rubocop` gems so we just need to remove `colorize` gem


[LEP-82]: https://dsdmoj.atlassian.net/browse/LEP-82?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ