### PR TITLE
Lep 91 remove unused assessment errors table

### DIFF
--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -23,7 +23,7 @@ class Assessment < ApplicationRecord
   has_many :properties, through: :capital_summary, dependent: :destroy
   has_many :vehicles, through: :capital_summary, dependent: :destroy
   has_many :capital_items, through: :capital_summary, dependent: :destroy
-  has_many :assessment_errors, dependent: :destroy
+  has_many :assessment_errors, dependent: nil
   has_many :explicit_remarks, dependent: :destroy
   has_many :employments, dependent: :destroy, class_name: "ApplicantEmployment"
   has_many :partner_employments, dependent: :destroy

--- a/db/migrate/20230414114501_drop_assessment_errors.rb
+++ b/db/migrate/20230414114501_drop_assessment_errors.rb
@@ -1,6 +1,6 @@
 class DropAssessmentErrors < ActiveRecord::Migration[7.0]
-    def change
-      drop_table :assessment_errors
+  def change
+    drop_table :assessment_errors do
     end
   end
-  
+end

--- a/db/migrate/20230414114501_drop_assessment_errors.rb
+++ b/db/migrate/20230414114501_drop_assessment_errors.rb
@@ -1,0 +1,6 @@
+class DropAssessmentErrors < ActiveRecord::Migration[7.0]
+    def change
+      drop_table :assessment_errors
+    end
+  end
+  

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_03_31_170201) do
+ActiveRecord::Schema[7.0].define(version: 2023_04_14_114501) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -25,14 +25,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_31_170201) do
     t.boolean "employed"
     t.boolean "receives_asylum_support", default: false, null: false
     t.index ["assessment_id"], name: "index_applicants_on_assessment_id"
-  end
-
-  create_table "assessment_errors", force: :cascade do |t|
-    t.uuid "assessment_id", null: false
-    t.uuid "record_id"
-    t.string "record_type"
-    t.string "error_message"
-    t.index ["assessment_id"], name: "index_assessment_errors_on_assessment_id"
   end
 
   create_table "assessments", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -50,8 +42,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_31_170201) do
 
   create_table "bank_holidays", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.text "dates"
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "capital_items", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -300,7 +292,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_31_170201) do
   end
 
   add_foreign_key "applicants", "assessments"
-  add_foreign_key "assessment_errors", "assessments"
   add_foreign_key "capital_items", "capital_summaries"
   add_foreign_key "capital_summaries", "assessments"
   add_foreign_key "cash_transaction_categories", "gross_income_summaries"

--- a/spec/services/cull_stale_assessments_service_spec.rb
+++ b/spec/services/cull_stale_assessments_service_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe CullStaleAssessmentsService do
   def create_assessment_and_associated_records
     ass = create :assessment
     create :applicant, assessment: ass
-    create :assessment_error, assessment: ass
+    # create :assessment_error, assessment: ass
     create_list :dependant, 2, assessment: ass
     create :capital_summary, :with_everything, :with_eligibilities, assessment: ass
     create :gross_income_summary,
@@ -59,7 +59,6 @@ RSpec.describe CullStaleAssessmentsService do
   def associated_models
     [
       Applicant,
-      AssessmentError,
       CapitalItem,
       CapitalSummary,
       CashTransactionCategory,


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/jira/software/c/projects/LEP/boards/1143?modal=detail&selectedIssue=LEP-91)

Describe what you did and why.

- Created migration to remove the assessment_errors table
- Removed the associated dependant option when deleting stale assessments

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
